### PR TITLE
Exposed OVERLOAD_VERSION to entire soltion instead of OvEditor

### DIFF
--- a/Sources/Overload/OvEditor/premake5.lua
+++ b/Sources/Overload/OvEditor/premake5.lua
@@ -1,17 +1,3 @@
--- Function to read the version number from VERSION.txt
-local function readVersion()
-    local versionFile = io.open("../../../VERSION.txt", "r")
-    if versionFile then
-        local version = versionFile:read("*l")
-        versionFile:close()
-        return version
-    else
-        error("Could not open VERSION.txt")
-    end
-end
-
-local version = readVersion()
-
 project "OvEditor"
 	language "C++"
 	cppdialect "C++20"
@@ -29,8 +15,6 @@ project "OvEditor"
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
 	characterset ("MBCS")
 	debugdir "%{wks.location}/../../Build/%{cfg.buildcfg}"
-
-	defines { "OVERLOAD_VERSION=\"" .. version .. "\"" }
 
 	postbuildcommands {
 		"for /f \"delims=|\" %%i in ('dir /B /S \"%{dependdir}\\*.dll\"') do xcopy /Q /Y \"%%i\" \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\"",

--- a/Sources/Overload/premake5.lua
+++ b/Sources/Overload/premake5.lua
@@ -16,8 +16,7 @@ workspace "Overload"
 	configurations { "Debug", "Release" }
 	platforms { "x64" }
 	startproject "OvEditor"
-	defines { "LUA_SCRIPTING" }
-	defines { "OVERLOAD_VERSION=\"" .. version .. "\"" }
+	defines { "LUA_SCRIPTING", "OVERLOAD_VERSION=\"" .. version .. "\"" }
 
 outputdir = "%{wks.location}/../../Bin/"
 objoutdir = "%{wks.location}/../../Bin-Int/"

--- a/Sources/Overload/premake5.lua
+++ b/Sources/Overload/premake5.lua
@@ -1,8 +1,23 @@
+-- Function to read the version number from VERSION.txt
+local function readVersion()
+    local versionFile = io.open("../../VERSION.txt", "r")
+    if versionFile then
+        local version = versionFile:read("*l")
+        versionFile:close()
+        return version
+    else
+        error("Could not open VERSION.txt")
+    end
+end
+
+local version = readVersion()
+
 workspace "Overload"
 	configurations { "Debug", "Release" }
 	platforms { "x64" }
 	startproject "OvEditor"
 	defines { "LUA_SCRIPTING" }
+	defines { "OVERLOAD_VERSION=\"" .. version .. "\"" }
 
 outputdir = "%{wks.location}/../../Bin/"
 objoutdir = "%{wks.location}/../../Bin-Int/"


### PR DESCRIPTION
Closes: #373 
1. Moved `readVersion()` to `Sources/Overload/premake5.lua` and added `OVERLOAD_VERSION` to `Overload`.
2. Removed `readVersion()` from `Sources/Overload/OvEditor/premake5.lua` and removed `OVERLOAD_VERSION` from `OvEditor` project.