### PR TITLE
Implemented a texture debugger editor panel

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/Rendering/FramebufferUtil.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/FramebufferUtil.cpp
@@ -26,7 +26,7 @@ namespace OvCore::Rendering::FramebufferUtil
 		p_width = static_cast<uint16_t>(std::max(1u, p_width));
 		p_height = static_cast<uint16_t>(std::max(1u, p_height));
 
-		const auto renderTexture = std::make_shared<Texture>();
+		const auto renderTexture = std::make_shared<Texture>(p_framebuffer.GetDebugName() + "/Color");
 
 		TextureDesc renderTextureDesc{
 			.width = p_width,

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/FramebufferUtil.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/FramebufferUtil.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include<format>
+
 #include <OvCore/Rendering/FramebufferUtil.h>
 #include <OvRendering/HAL/Framebuffer.h>
 #include <OvRendering/HAL/Renderbuffer.h>
@@ -26,7 +28,10 @@ namespace OvCore::Rendering::FramebufferUtil
 		p_width = static_cast<uint16_t>(std::max(1u, p_width));
 		p_height = static_cast<uint16_t>(std::max(1u, p_height));
 
-		const auto renderTexture = std::make_shared<Texture>(p_framebuffer.GetDebugName() + "/Color");
+		const auto renderTexture = std::make_shared<Texture>(std::format(
+			"{}/Color",
+			p_framebuffer.GetDebugName()
+		));
 
 		TextureDesc renderTextureDesc{
 			.width = p_width,

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
@@ -14,7 +14,12 @@ constexpr uint32_t kExposureBufferResolution = 1;
 
 OvCore::Rendering::PostProcess::AutoExposureEffect::AutoExposureEffect(
 	OvRendering::Core::CompositeRenderer& p_renderer
-) :	AEffect(p_renderer)
+) :	AEffect(p_renderer),
+	m_luminanceBuffer{ "Luminance" },
+	m_exposurePingPongBuffer{
+		OvRendering::HAL::Framebuffer{"ExposurePingPong0"},
+		OvRendering::HAL::Framebuffer{"ExposurePingPong1"}
+	}
 {
 	for (auto& buffer : m_exposurePingPongBuffer)
 	{

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/BloomEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/BloomEffect.cpp
@@ -10,7 +10,11 @@
 #include <OvCore/ResourceManagement/ShaderManager.h>
 
 OvCore::Rendering::PostProcess::BloomEffect::BloomEffect(OvRendering::Core::CompositeRenderer& p_renderer) :
-	AEffect(p_renderer)
+	AEffect(p_renderer),
+	m_bloomPingPong{
+		OvRendering::HAL::Framebuffer{"BloomPingPong0"},
+		OvRendering::HAL::Framebuffer{"BloomPingPong1"}
+	}
 {
 	for (auto& buffer : m_bloomPingPong)
 	{

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcessRenderPass.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcessRenderPass.cpp
@@ -13,7 +13,11 @@
 #include <OvRendering/Core/CompositeRenderer.h>
 
 OvCore::Rendering::PostProcessRenderPass::PostProcessRenderPass(OvRendering::Core::CompositeRenderer& p_renderer) :
-	OvRendering::Core::ARenderPass(p_renderer)
+	OvRendering::Core::ARenderPass(p_renderer),
+	m_pingPongBuffers{
+		OvRendering::HAL::Framebuffer{"PostProcessBlitPingPong0"},
+		OvRendering::HAL::Framebuffer{"PostProcessBlitPingPong1"}
+	}
 {
 	for (auto& buffer : m_pingPongBuffers)
 	{

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/Context.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/Context.h
@@ -32,6 +32,7 @@
 #include <OvAudio/Core/AudioPlayer.h>
 
 #include "OvEditor/Core/EditorResources.h"
+#include <OvEditor/Utils/TextureRegistry.h>
 
 namespace OvEditor::Core
 {
@@ -81,6 +82,7 @@ namespace OvEditor::Core
 		std::unique_ptr<OvWindowing::Context::Device> device;
 		std::unique_ptr<OvWindowing::Window> window;
 		std::unique_ptr<OvWindowing::Inputs::InputManager> inputManager;
+		std::unique_ptr<OvEditor::Utils::TextureRegistry> textureRegistry;
 		std::unique_ptr<OvRendering::Context::Driver> driver;
 		std::unique_ptr<OvUI::Core::UIManager> uiManager;
 		std::unique_ptr<OvPhysics::Core::PhysicsEngine> physicsEngine;

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/TextureDebugger.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/TextureDebugger.h
@@ -1,0 +1,68 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <unordered_map>
+#include <memory>
+
+#include <OvRendering/HAL/Texture.h>
+#include <OvUI/Widgets/Visual/Image.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
+#include <OvUI/Panels/PanelWindow.h>
+#include <OvEditor/Utils/TextureRegistry.h>
+
+namespace OvEditor::Panels
+{
+	enum class EScaleMode : uint8_t
+	{
+		ONE_TO_ONE,
+		PERCENTAGE_5,
+		PERCENTAGE_10,
+		PERCENTAGE_25,
+		PERCENTAGE_50,
+		PERCENTAGE_100,
+		PERCENTAGE_200,
+		PERCENTAGE_400,
+		PERCENTAGE_800
+	};
+
+	class TextureDebugger : public OvUI::Panels::PanelWindow
+	{
+	public:
+		/**
+		* Creates a texture debugger.
+		* @param p_title
+		* @param p_opened
+		* @param p_windowSettings
+		*/
+		TextureDebugger(
+			const std::string& p_title,
+			bool p_opened,
+			const OvUI::Settings::PanelWindowSettings& p_windowSettings
+		);
+
+		/**
+		* Destroys the texture debugger.
+		*/
+		~TextureDebugger();
+
+		/**
+		* Updates the texture debugger.
+		* @param p_deltaTime
+		*/
+		void Update(float p_deltaTime);
+
+	private:
+		EScaleMode m_scaleMode = EScaleMode::ONE_TO_ONE;
+		OvUI::Widgets::Selection::ComboBox& m_textureSelector;
+		OvUI::Widgets::Selection::ComboBox& m_scaleSelector;
+		OvUI::Widgets::Visual::Image& m_image;
+		OvTools::Eventing::ListenerID m_creationListenerID;
+		OvTools::Eventing::ListenerID m_destructionListenerID;
+		OvTools::Utils::OptRef<OvRendering::HAL::Texture> m_selectedTexture;
+	};
+}

--- a/Sources/Overload/OvEditor/include/OvEditor/Utils/TextureRegistry.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Utils/TextureRegistry.h
@@ -1,0 +1,63 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <span>
+#include <unordered_map>
+
+#include <OvRendering/HAL/Texture.h>
+#include <OvTools/Utils/OptRef.h>
+
+namespace OvEditor::Utils
+{
+	/**
+	* Structure describing a texture registry entry.
+	*/
+	struct TextureRegistryEntryDesc
+	{
+		const uint32_t id;
+		const OvRendering::HAL::Texture* texture;
+	};
+
+	/**
+	* Class exposing tools to manage textures.
+	*/
+	class TextureRegistry
+	{
+	public:
+		OvTools::Eventing::Event<const TextureRegistryEntryDesc&> textureAddedEvent;
+		OvTools::Eventing::Event<const TextureRegistryEntryDesc&> textureRemovedEvent;
+
+	public:
+		/**
+		* Creates the TextureRegistry.
+		*/
+		TextureRegistry();
+
+		/**
+		* Destroys the TextureRegistry.
+		*/
+		~TextureRegistry();
+
+		/**
+		* Returns the texture associated with the given id
+		* @param p_id
+		*/
+		OvTools::Utils::OptRef<OvRendering::HAL::Texture> GetTexture(uint32_t p_id) const;
+
+		/**
+		* Returns all the texture ids
+		*/
+		std::span<const uint32_t> GetTextureIDs() const;
+
+	private:
+		OvTools::Eventing::ListenerID m_creationListenerID;
+		OvTools::Eventing::ListenerID m_destructionListenerID;
+		std::unordered_map<uint32_t, OvRendering::HAL::Texture*> m_textures;
+		std::vector<uint32_t> m_quickAccessTextureIDs;
+	};
+}

--- a/Sources/Overload/OvEditor/layout.ini
+++ b/Sources/Overload/OvEditor/layout.ini
@@ -184,6 +184,12 @@ Size=892,498
 Collapsed=0
 DockId=0x0000000A,1
 
+[Window][Texture Debugger##16]
+Pos=1139,719
+Size=318,361
+Collapsed=0
+DockId=0x00000006,1
+
 [Docking][Data]
 DockSpace           ID=0x3F20F338 Window=0xEFEA1D90 Pos=0,24 Size=1600,876 Split=X NoWindowMenuButton=1
   DockNode          ID=0x0000000F Parent=0x3F20F338 SizeRef=1214,1336 Split=X NoWindowMenuButton=1

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -109,6 +109,7 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 
 	/* Graphics context creation */
 	driver = std::make_unique<OvRendering::Context::Driver>(OvRendering::Settings::DriverSettings{ true });
+	textureRegistry = std::make_unique<OvEditor::Utils::TextureRegistry>();
 
 	std::filesystem::create_directories(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\");
 
@@ -152,6 +153,7 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 	ServiceLocator::Provide<OvAudio::Core::AudioEngine>(*audioEngine);
 	ServiceLocator::Provide<OvAudio::Core::AudioPlayer>(*audioPlayer);
 	ServiceLocator::Provide<OvCore::Scripting::ScriptEngine>(*scriptEngine);
+	ServiceLocator::Provide<OvEditor::Utils::TextureRegistry>(*textureRegistry);
 
 	ApplyProjectSettings();
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -23,6 +23,7 @@
 #include "OvEditor/Panels/MaterialEditor.h"
 #include "OvEditor/Panels/ProjectSettings.h"
 #include "OvEditor/Panels/AssetProperties.h"
+#include <OvEditor/Panels/TextureDebugger.h>
 #include "OvEditor/Settings/EditorSettings.h"
 
 using namespace OvCore::ResourceManagement;
@@ -69,6 +70,7 @@ void OvEditor::Core::Editor::SetupUI()
 	m_panelsManager.CreatePanel<Panels::MaterialEditor>("Material Editor", false, settings);
 	m_panelsManager.CreatePanel<Panels::ProjectSettings>("Project Settings", false, settings);
 	m_panelsManager.CreatePanel<Panels::AssetProperties>("Asset Properties", false, settings);
+	m_panelsManager.CreatePanel<Panels::TextureDebugger>("Texture Debugger", false, settings);
 
 	// Needs to be called after all panels got created, because some settings in this menu depend on other panels
 	m_panelsManager.GetPanelAs<Panels::MenuBar>("Menu Bar").InitializeSettingsMenu();
@@ -171,6 +173,7 @@ void OvEditor::Core::Editor::UpdateEditorPanels(float p_deltaTime)
 	auto& sceneView = m_panelsManager.GetPanelAs<OvEditor::Panels::SceneView>("Scene View");
 	auto& gameView = m_panelsManager.GetPanelAs<OvEditor::Panels::GameView>("Game View");
 	auto& assetView = m_panelsManager.GetPanelAs<OvEditor::Panels::AssetView>("Asset View");
+	auto& textureDebugger = m_panelsManager.GetPanelAs<OvEditor::Panels::TextureDebugger>("Texture Debugger");
 
 	menuBar.HandleShortcuts(p_deltaTime);
 
@@ -199,6 +202,12 @@ void OvEditor::Core::Editor::UpdateEditorPanels(float p_deltaTime)
 	{
 		PROFILER_SPY("Hardware Info Update");
 		hardwareInfo.Update(p_deltaTime);
+	}
+
+	if (textureDebugger.IsOpened())
+	{
+		PROFILER_SPY("Texture Debugger Update");
+		textureDebugger.Update(p_deltaTime);
 	}
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AView.cpp
@@ -14,7 +14,8 @@ OvEditor::Panels::AView::AView
 	const std::string& p_title,
 	bool p_opened,
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
-) : PanelWindow(p_title, p_opened, p_windowSettings)
+) : PanelWindow(p_title, p_opened, p_windowSettings),
+	m_framebuffer(p_title)
 {
 	OvCore::Rendering::FramebufferUtil::SetupFramebuffer(
 		m_framebuffer,

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/TextureDebugger.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/TextureDebugger.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <array>
+#include <format>
 
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvDebug/Assertion.h>
@@ -61,7 +62,11 @@ namespace OvEditor::Panels
 	void AddOption(OvUI::Widgets::Selection::ComboBox& p_selector, const OvRendering::HAL::Texture& p_texture)
 	{
 		const auto id = p_texture.GetID();
-		p_selector.choices[id] = "Texture " + std::to_string(id) + ": " + p_texture.GetDebugName();
+		p_selector.choices[id] = std::format(
+			"Texture {}: {}",
+			id,
+			p_texture.GetDebugName()
+		);
 	}
 
 	float CalculateOneToOneScale(const OvMaths::FVector2& p_windowSize, OvRendering::HAL::Texture& p_texture)
@@ -144,7 +149,12 @@ namespace OvEditor::Panels
 		{
 			if (p_desc.id != 0)
 			{
-				m_textureSelector.choices[p_desc.id] = "Texture " + std::to_string(p_desc.id) + ": " + p_desc.texture->GetDebugName();
+				m_textureSelector.choices[p_desc.id] = std::format(
+					"Texture {}: {}",
+					p_desc.id,
+					p_desc.texture->GetDebugName()
+				);
+
 				AddOption(m_textureSelector, *p_desc.texture);
 			}
 		};

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/TextureDebugger.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/TextureDebugger.cpp
@@ -1,0 +1,213 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <array>
+
+#include <OvCore/Global/ServiceLocator.h>
+#include <OvDebug/Assertion.h>
+#include <OvDebug/Logger.h>
+#include <OvEditor/Panels/TextureDebugger.h>
+#include <OvRendering/HAL/Texture.h>
+#include <OvTools/Utils/EnumMapper.h>
+
+template <>
+struct OvTools::Utils::MappingFor<OvEditor::Panels::EScaleMode, std::string>
+{
+	static constexpr char one_to_one[] = "1:1";
+	static constexpr char percentage_5[] = "5%";
+	static constexpr char percentage_10[] = "10%";
+	static constexpr char percentage_25[] = "25%";
+	static constexpr char percentage_50[] = "50%";
+	static constexpr char percentage_100[] = "100%";
+	static constexpr char percentage_200[] = "200%";
+	static constexpr char percentage_400[] = "400%";
+	static constexpr char percentage_800[] = "800%";
+
+	using enum OvEditor::Panels::EScaleMode;
+	using type = std::tuple<
+		EnumValuePair<ONE_TO_ONE, one_to_one>,
+		EnumValuePair<PERCENTAGE_5, percentage_5>,
+		EnumValuePair<PERCENTAGE_10, percentage_10>,
+		EnumValuePair<PERCENTAGE_25, percentage_25>,
+		EnumValuePair<PERCENTAGE_50, percentage_50>,
+		EnumValuePair<PERCENTAGE_100, percentage_100>,
+		EnumValuePair<PERCENTAGE_200, percentage_200>,
+		EnumValuePair<PERCENTAGE_400, percentage_400>,
+		EnumValuePair<PERCENTAGE_800, percentage_800>
+	>;
+};
+
+template <>
+struct OvTools::Utils::MappingFor<OvEditor::Panels::EScaleMode, float>
+{
+	using enum OvEditor::Panels::EScaleMode;
+	using type = std::tuple<
+		EnumValuePair<PERCENTAGE_5, 0.05f>,
+		EnumValuePair<PERCENTAGE_10, 0.1f>,
+		EnumValuePair<PERCENTAGE_25, 0.25f>,
+		EnumValuePair<PERCENTAGE_50, 0.5f>,
+		EnumValuePair<PERCENTAGE_100, 1.0f>,
+		EnumValuePair<PERCENTAGE_200, 2.0f>,
+		EnumValuePair<PERCENTAGE_400, 4.0f>,
+		EnumValuePair<PERCENTAGE_800, 8.0f>
+	>;
+};
+
+namespace OvEditor::Panels 
+{
+	void AddOption(OvUI::Widgets::Selection::ComboBox& p_selector, const OvRendering::HAL::Texture& p_texture)
+	{
+		const auto id = p_texture.GetID();
+		p_selector.choices[id] = "Texture " + std::to_string(id) + ": " + p_texture.GetDebugName();
+	}
+
+	float CalculateOneToOneScale(const OvMaths::FVector2& p_windowSize, OvRendering::HAL::Texture& p_texture)
+	{
+		constexpr float kPanelImageMarginX = 45.0f;
+		constexpr float kPanelImageMarginY = 120.0f; // Based on the size of the settings above the image
+
+		const auto& texDesc = p_texture.GetDesc();
+		float safeSizeX = p_windowSize.x - kPanelImageMarginX;
+		float safeSizeY = p_windowSize.y - kPanelImageMarginY;
+
+		return std::min(safeSizeX / texDesc.width, safeSizeY / texDesc.height);
+	}
+
+	OvMaths::FVector2 CalculateImageSize(EScaleMode p_mode, const OvMaths::FVector2& p_windowSize, OvRendering::HAL::Texture& p_texture)
+	{
+		const float scale =
+			p_mode == EScaleMode::ONE_TO_ONE ?
+			CalculateOneToOneScale(p_windowSize, p_texture) :
+			OvTools::Utils::ToValueImpl<EScaleMode, float>(p_mode);
+
+		return {
+			p_texture.GetDesc().width * scale,
+			p_texture.GetDesc().height * scale
+		};
+	}
+
+	TextureDebugger::TextureDebugger(
+		const std::string& p_title,
+		bool p_opened,
+		const OvUI::Settings::PanelWindowSettings& p_windowSettings
+	) :
+		PanelWindow(p_title, p_opened, p_windowSettings),
+		m_image(CreateWidget<OvUI::Widgets::Visual::Image>(0, OvMaths::FVector2::Zero)),
+		m_textureSelector(CreateWidget<OvUI::Widgets::Selection::ComboBox>()),
+		m_scaleSelector(CreateWidget<OvUI::Widgets::Selection::ComboBox>())
+	{
+		auto& textureRegistry = OVSERVICE(OvEditor::Utils::TextureRegistry);
+
+		allowHorizontalScrollbar = true;
+
+		constexpr int kNoneTextureID = 0;
+
+		m_textureSelector.choices = { {kNoneTextureID, "None"} };
+
+		for (auto& textureID : textureRegistry.GetTextureIDs())
+		{
+			if (auto texture = textureRegistry.GetTexture(textureID); texture.has_value())
+			{
+				AddOption(m_textureSelector, texture.value());
+			}
+		}
+
+		m_textureSelector.ValueChangedEvent += [this, &textureRegistry](int p_selectedTextureID)
+		{
+			if (p_selectedTextureID == kNoneTextureID)
+			{
+				m_image.textureID = { 0U };
+				m_image.size = OvMaths::FVector2::Zero;
+			}
+			else
+			{
+				if (auto texture = textureRegistry.GetTexture(p_selectedTextureID))
+				{
+					m_selectedTexture = texture;
+					m_image.textureID = { texture->GetID() };
+					m_image.size = CalculateImageSize(m_scaleMode, GetSize(), texture.value());
+				}
+			}
+		};
+
+		// Selecting the last texture, by default
+		if (m_textureSelector.choices.size() > 1)
+		{
+			m_textureSelector.currentChoice = static_cast<int>(m_textureSelector.choices.size() - 1ULL);
+			m_textureSelector.ValueChangedEvent.Invoke(m_textureSelector.currentChoice);
+		}
+
+		m_creationListenerID = textureRegistry.textureAddedEvent += [this](const auto& p_desc)
+		{
+			if (p_desc.id != 0)
+			{
+				m_textureSelector.choices[p_desc.id] = "Texture " + std::to_string(p_desc.id) + ": " + p_desc.texture->GetDebugName();
+				AddOption(m_textureSelector, *p_desc.texture);
+			}
+		};
+
+		m_destructionListenerID = textureRegistry.textureRemovedEvent += [this](const auto& p_desc)
+		{
+			if (p_desc.id != 0)
+			{
+				m_textureSelector.choices.erase(p_desc.id);
+				if (m_textureSelector.currentChoice == p_desc.id)
+				{
+					m_textureSelector.currentChoice = 0;
+					m_textureSelector.ValueChangedEvent.Invoke(0);
+					m_selectedTexture = std::nullopt;
+				}
+			}
+		};
+
+		auto scaleEntry = [](auto p_mode) {
+			return std::pair{
+				static_cast<int>(p_mode),
+				OvTools::Utils::ToValueImpl<EScaleMode, std::string>(p_mode)
+			};
+		};
+
+		using enum EScaleMode;
+		m_scaleSelector.choices = {
+			scaleEntry(ONE_TO_ONE),
+			scaleEntry(PERCENTAGE_5),
+			scaleEntry(PERCENTAGE_10),
+			scaleEntry(PERCENTAGE_25),
+			scaleEntry(PERCENTAGE_50),
+			scaleEntry(PERCENTAGE_100),
+			scaleEntry(PERCENTAGE_200),
+			scaleEntry(PERCENTAGE_400),
+			scaleEntry(PERCENTAGE_800)
+		};
+		m_scaleSelector.currentChoice = 0;
+		m_scaleSelector.ValueChangedEvent += [this](int p_selectedScale) {
+			m_scaleMode = static_cast<EScaleMode>(p_selectedScale);
+			// Reset the image size if no texture is selected
+			if (m_selectedTexture)
+			{
+				m_image.size = CalculateImageSize(m_scaleMode, GetSize(), m_selectedTexture.value());
+			}
+			else
+			{
+				m_image.size = OvMaths::FVector2::Zero;
+			}
+		};
+	}
+
+	TextureDebugger::~TextureDebugger()
+	{
+		OvRendering::HAL::Texture::CreationEvent -= m_creationListenerID;
+		OvRendering::HAL::Texture::DestructionEvent -= m_destructionListenerID;
+	}
+
+	void TextureDebugger::Update(float p_deltaTime)
+	{
+		if (m_selectedTexture)
+		{
+			m_image.size = CalculateImageSize(m_scaleMode, GetSize(), m_selectedTexture.value());
+		}
+	}
+}

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -15,7 +15,8 @@
 #include <OvCore/Rendering/FramebufferUtil.h>
 
 OvEditor::Rendering::PickingRenderPass::PickingRenderPass(OvRendering::Core::CompositeRenderer& p_renderer) :
-	OvRendering::Core::ARenderPass(p_renderer)
+	OvRendering::Core::ARenderPass(p_renderer),
+	m_actorPickingFramebuffer("ActorPicking")
 {
 	OvCore::Rendering::FramebufferUtil::SetupFramebuffer(
 		m_actorPickingFramebuffer, 1, 1, true, false, false

--- a/Sources/Overload/OvEditor/src/OvEditor/Utils/TextureRegistry.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Utils/TextureRegistry.cpp
@@ -1,0 +1,58 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvEditor/Utils/TextureRegistry.h>
+
+namespace OvEditor::Utils
+{
+	TextureRegistry::TextureRegistry()
+	{
+		using namespace OvRendering::HAL;
+
+		m_creationListenerID = Texture::CreationEvent += [this](Texture& p_texture)
+		{
+			const auto id = p_texture.GetID();
+			if (id != 0)
+			{
+				m_quickAccessTextureIDs.push_back(id);
+				m_textures[id] = &p_texture;
+				textureAddedEvent.Invoke({ id, &p_texture });
+			}
+		};
+
+		m_destructionListenerID = Texture::DestructionEvent += [this](Texture& p_texture)
+		{
+			const auto id = p_texture.GetID();
+			if (id != 0)
+			{
+				m_quickAccessTextureIDs.erase(std::ranges::find(m_quickAccessTextureIDs, id));
+				m_textures.erase(id);
+				textureRemovedEvent.Invoke({ id, &p_texture });
+			}
+		};
+	}
+
+	TextureRegistry::~TextureRegistry()
+	{
+		OvRendering::HAL::Texture::CreationEvent -= m_creationListenerID;
+		OvRendering::HAL::Texture::DestructionEvent -= m_destructionListenerID;
+	}
+
+	OvTools::Utils::OptRef<OvRendering::HAL::Texture> TextureRegistry::GetTexture(uint32_t p_id) const
+	{
+		if (m_textures.contains(p_id))
+		{
+			return OvTools::Utils::OptRef<OvRendering::HAL::Texture>(*m_textures.at(p_id));
+		}
+
+		return std::nullopt;
+	}
+
+	std::span<const uint32_t> TextureRegistry::GetTextureIDs() const
+	{
+		return m_quickAccessTextureIDs;
+	}
+}

--- a/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
@@ -143,7 +143,7 @@ OvGame::Core::Context::Context() :
 	ServiceLocator::Provide<OvAudio::Core::AudioPlayer>(*audioPlayer);
 	ServiceLocator::Provide<OvCore::Scripting::ScriptEngine>(*scriptEngine);
 
-	framebuffer = std::make_unique<OvRendering::HAL::Framebuffer>();
+	framebuffer = std::make_unique<OvRendering::HAL::Framebuffer>("Main");
 
 	OvCore::Rendering::FramebufferUtil::SetupFramebuffer(
 		*framebuffer,

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/Common/TFramebuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/Common/TFramebuffer.h
@@ -50,8 +50,9 @@ namespace OvRendering::HAL
 
 		/**
 		* Creates a framebuffer.
+		* @param p_debugName A name used to identify the framebuffer for debugging purposes
 		*/
-		TFramebuffer();
+		TFramebuffer(std::string_view p_debugName = std::string_view{});
 
 		/**
 		* Destroys the framebuffer.
@@ -163,6 +164,11 @@ namespace OvRendering::HAL
 			Settings::EPixelDataType p_type,
 			void* p_data
 		) const;
+
+		/**
+		* Returns the debug name of the framebuffer.
+		*/
+		const std::string& GetDebugName() const;
 
 	protected:
 		FramebufferContext m_context;

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/Common/TTexture.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/Common/TTexture.h
@@ -6,10 +6,13 @@
 
 #pragma once
 
+#include <string>
+
 #include <OvMaths/FVector4.h>
 #include <OvRendering/HAL/Common/TTextureHandle.h>
 #include <OvRendering/Settings/EGraphicsBackend.h>
 #include <OvRendering/Settings/TextureDesc.h>
+#include <OvTools/Eventing/Event.h>
 
 namespace OvRendering::HAL
 {
@@ -22,8 +25,9 @@ namespace OvRendering::HAL
 	public:
 		/**
 		* Creates a texture.
+		* @param p_debugName A name used to identify the texture for debugging purposes
 		*/
-		TTexture();
+		TTexture(std::string_view p_debugName = std::string_view{});
 
 		/**
 		* Destroys the texture.
@@ -76,6 +80,15 @@ namespace OvRendering::HAL
 		* @param p_color
 		*/
 		void SetBorderColor(const OvMaths::FVector4& p_color);
+
+		/**
+		* Returns the debug name of the texture.
+		*/
+		const std::string& GetDebugName() const;
+
+	public:
+		static OvTools::Eventing::Event<TTexture&> CreationEvent;
+		static OvTools::Eventing::Event<TTexture&> DestructionEvent;
 
 	private:
 		TextureContext m_textureContext;

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/None/NoneFramebuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/None/NoneFramebuffer.h
@@ -20,6 +20,7 @@ namespace OvRendering::HAL
 		using Attachment = TFramebufferAttachment<Backend, GLTextureContext, GLTextureHandleContext, GLRenderbufferContext>;
 
 		bool valid = false;
+		std::string debugName = "";
 		std::unordered_map<std::underlying_type_t<Settings::EFramebufferAttachment>, Attachment> attachments;
 	};
 

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/None/NoneTexture.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/None/NoneTexture.h
@@ -15,6 +15,7 @@ namespace OvRendering::HAL
 	{
 		OvRendering::Settings::TextureDesc desc;
 		bool allocated = false;
+		std::string debugName = "";
 	};
 
 	using NoneTexture = TTexture<Settings::EGraphicsBackend::NONE, NoneTextureContext, NoneTextureHandleContext>;

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLFramebuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLFramebuffer.h
@@ -21,6 +21,7 @@ namespace OvRendering::HAL
 
 		uint32_t id = 0;
 		bool valid = false;
+		std::string debugName;
 		std::unordered_map<uint32_t, Attachment> attachments;
 	};
 

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLTexture.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLTexture.h
@@ -15,6 +15,7 @@ namespace OvRendering::HAL
 	{
 		Settings::TextureDesc desc;
 		bool allocated = false;
+		std::string debugName;
 	};
 
 	using GLTexture = TTexture<Settings::EGraphicsBackend::OPENGL, GLTextureContext, GLTextureHandleContext>;

--- a/Sources/Overload/OvRendering/src/OvRendering/Entities/Light.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Entities/Light.cpp
@@ -18,7 +18,7 @@ namespace
 		using namespace OvRendering::HAL;
 		using namespace OvRendering::Settings;
 
-		const auto renderTexture = std::make_shared<Texture>();
+		const auto renderTexture = std::make_shared<Texture>(p_framebuffer.GetDebugName() + "/Depth");
 
 		TextureDesc renderTextureDesc{
 			.width = p_resolution,
@@ -60,7 +60,7 @@ void OvRendering::Entities::Light::UpdateShadowData(const OvRendering::Entities:
 	{
 		if (!shadowBuffer)
 		{
-			shadowBuffer = std::make_unique<OvRendering::HAL::Framebuffer>();
+			shadowBuffer = std::make_unique<OvRendering::HAL::Framebuffer>("DirectionalShadow");
 			SetupFramebufferForShadowMapping(*shadowBuffer, static_cast<uint32_t>(shadowMapResolution));
 		}
 		else

--- a/Sources/Overload/OvRendering/src/OvRendering/Entities/Light.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Entities/Light.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <format>
+
 #include <OvDebug/Assertion.h>
 #include <OvRendering/Entities/Light.h>
 #include <OvRendering/HAL/Renderbuffer.h>
@@ -18,7 +20,10 @@ namespace
 		using namespace OvRendering::HAL;
 		using namespace OvRendering::Settings;
 
-		const auto renderTexture = std::make_shared<Texture>(p_framebuffer.GetDebugName() + "/Depth");
+		const auto renderTexture = std::make_shared<Texture>(std::format(
+			"{}/Depth",
+			p_framebuffer.GetDebugName()
+		));
 
 		TextureDesc renderTextureDesc{
 			.width = p_resolution,

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/None/NoneFramebuffer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/None/NoneFramebuffer.cpp
@@ -27,7 +27,8 @@ void OvRendering::HAL::NoneFramebuffer::Attach(std::shared_ptr<NoneTexture> p_to
 }
 
 template<>
-OvRendering::HAL::NoneFramebuffer::TFramebuffer()
+OvRendering::HAL::NoneFramebuffer::TFramebuffer(std::string_view p_debugName) :
+	m_context{ .debugName = std::string{p_debugName} }
 {
 }
 

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/None/NoneTexture.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/None/NoneTexture.cpp
@@ -8,14 +8,20 @@
 
 #include <OvRendering/HAL/None//NoneTexture.h>
 
+OvTools::Eventing::Event<OvRendering::HAL::NoneTexture&> OvRendering::HAL::NoneTexture::CreationEvent;
+OvTools::Eventing::Event<OvRendering::HAL::NoneTexture&> OvRendering::HAL::NoneTexture::DestructionEvent;
+
 template<>
-OvRendering::HAL::NoneTexture::TTexture() : TTextureHandle{ 0 }
+OvRendering::HAL::NoneTexture::TTexture(std::string_view p_debugName) : TTextureHandle{ 0 }
 {
+	m_textureContext.debugName = p_debugName;
+	CreationEvent.Invoke(*this);
 }
 
 template<>
 OvRendering::HAL::NoneTexture::~TTexture()
 {
+	DestructionEvent.Invoke(*this);
 }
 
 template<>

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLFramebuffer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLFramebuffer.cpp
@@ -43,7 +43,8 @@ void OvRendering::HAL::GLFramebuffer::Attach(
 }
 
 template<>
-OvRendering::HAL::GLFramebuffer::TFramebuffer()
+OvRendering::HAL::GLFramebuffer::TFramebuffer(std::string_view p_debugName) :
+	m_context{ .debugName = std::string{p_debugName} }
 {
 	glGenFramebuffers(1, &m_context.id);
 }
@@ -249,4 +250,10 @@ void OvRendering::HAL::GLFramebuffer::ReadPixels(
 		p_data
 	);
 	Unbind();
+}
+
+template<>
+const std::string& OvRendering::HAL::GLFramebuffer::GetDebugName() const
+{
+	return m_context.debugName;
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLTexture.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLTexture.cpp
@@ -11,6 +11,9 @@
 #include <OvDebug/Assertion.h>
 #include <OvDebug/Logger.h>
 
+OvTools::Eventing::Event<OvRendering::HAL::GLTexture&> OvRendering::HAL::GLTexture::CreationEvent;
+OvTools::Eventing::Event<OvRendering::HAL::GLTexture&> OvRendering::HAL::GLTexture::DestructionEvent;
+
 namespace
 {
 	constexpr uint32_t CalculateMipMapLevels(uint32_t p_width, uint32_t p_height)
@@ -30,15 +33,18 @@ namespace
 }
 
 template<>
-OvRendering::HAL::GLTexture::TTexture()
+OvRendering::HAL::GLTexture::TTexture(std::string_view p_debugName)
 {
 	glGenTextures(1, &m_context.id);
+	m_textureContext.debugName = p_debugName;
+	CreationEvent.Invoke(*this);
 }
 
 template<>
 OvRendering::HAL::GLTexture::~TTexture()
 {
 	glDeleteTextures(1, &m_context.id);
+	DestructionEvent.Invoke(*this);
 }
 
 template<>
@@ -181,4 +187,10 @@ void OvRendering::HAL::GLTexture::SetBorderColor(const OvMaths::FVector4& p_colo
 {
 	OVASSERT(IsValid(), "Cannot set border color for a texture before it has been allocated");
 	glTextureParameterfvEXT(m_context.id, GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, &p_color.x);
+}
+
+template<>
+const std::string& OvRendering::HAL::GLTexture::GetDebugName() const
+{
+	return m_textureContext.debugName;
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "OvRendering/Resources/Loaders/TextureLoader.h"
+#include <OvTools/Utils/PathParser.h>
 
 namespace
 {
@@ -77,7 +78,7 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 {
 	if (Image image{ p_filepath })
 	{
-		auto texture = std::make_unique<HAL::Texture>();
+		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filepath));
 		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap);
 		return new Texture{ p_filepath, std::move(texture) };
 	}
@@ -99,7 +100,7 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 
 OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::CreateFromMemory(uint8_t* p_data, uint32_t p_width, uint32_t p_height, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap)
 {
-	auto texture = std::make_unique<HAL::Texture>();
+	auto texture = std::make_unique<HAL::Texture>("FromMemory");
 	PrepareTexture(*texture, p_data, p_minFilter, p_magFilter, p_width, p_height, p_generateMipmap);
 	return new Texture("", std::move(texture));
 }
@@ -108,7 +109,7 @@ void OvRendering::Resources::Loaders::TextureLoader::Reload(Texture& p_texture, 
 {
 	if (Image image{ p_filePath })
 	{
-		auto texture = std::make_unique<HAL::Texture>();
+		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filePath));
 		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap);
 		p_texture.SetTexture(std::move(texture));
 	}


### PR DESCRIPTION
## Description
* Created editor panel to debug textures with:
  * a combo box to select a texture
  * a combo box to select the scaling mode (`1:1`, `5%`, `10%`, ..., up to `800%`)
* Added a `std::string` to `FramebufferContext` and `TextureContext` to store a debug name for the object
* Added a `TextureRegistry` class to track texture creation/destruction (registered as a service, and used by the `TextureDebugger` panel).
  * Since the `TextureRegistry` can be (and is) created right after the graphics driver, it can track ALL the texture creations/destructions, and report to the `TextureDebugger` once the latter is created, hence the interest in decoupling them.
* Added static events (creation/destruction) to `Texture` for the `TextureRegistry` to listen to
* Updated framebuffer and texture creations to set a debug name

## To-Do
- [x] Merge https://github.com/Overload-Technologies/Overload/pull/394
- [x] Update the base branch from feature/fully_agnostic_renderer to main

## Screenshots
![image](https://github.com/user-attachments/assets/c91a0978-995a-409f-8e7d-052e6e5cfa19)

## Videos
https://github.com/user-attachments/assets/136a3545-805b-444b-9258-7074dda36e41

