### PR TITLE
Refactored `IniFile` to remove `static_assert(false)`

### DIFF
--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
@@ -9,9 +9,15 @@
 #include <string>
 #include <unordered_map>
 
-
 namespace OvTools::Filesystem
 {
+	template<typename T>
+	concept SupportedIniType =
+		std::same_as<T, bool> ||
+		std::same_as<T, std::string> ||
+		std::integral<T> ||
+		std::floating_point<T>;
+
 	/**
 	* The IniFile class represents a file .ini that stores a set of attributes/values that can get read and written
 	*/
@@ -40,10 +46,10 @@ namespace OvTools::Filesystem
 
 		/**
 		* Return the value attached to the given key
-		* If the key doesn't exist, a default value is returned (0, false, "NULL")
+		* If the key doesn't exist, a default value is returned
 		* @param p_key
 		*/
-		template<typename T>
+		template<SupportedIniType T>
 		T Get(const std::string& p_key);
 
 		/**
@@ -52,7 +58,7 @@ namespace OvTools::Filesystem
 		* @param p_key
 		* @param p_default
 		*/
-		template<typename T>
+		template<SupportedIniType T>
 		T GetOrDefault(const std::string& p_key, T p_default);
 
 		/**
@@ -60,7 +66,7 @@ namespace OvTools::Filesystem
 		* @param p_key
 		* @param p_outValue
 		*/
-		template<typename T>
+		template<SupportedIniType T>
 		bool TryGet(const std::string& p_key, T& p_outValue);
 
 		/**
@@ -68,7 +74,7 @@ namespace OvTools::Filesystem
 		* @param p_key
 		* @param p_value
 		*/
-		template<typename T>
+		template<SupportedIniType T>
 		bool Set(const std::string& p_key, const T& p_value);
 
 		/**
@@ -76,7 +82,7 @@ namespace OvTools::Filesystem
 		* @param p_key
 		* @param p_value
 		*/
-		template<typename T>
+		template<SupportedIniType T>
 		bool Add(const std::string& p_key, const T& p_value);
 
 		/**
@@ -96,24 +102,15 @@ namespace OvTools::Filesystem
 		*/
 		bool IsKeyExisting(const std::string& p_key) const;
 
-		/**
-		* Get the content stored in the ini file as a vector of strings (Each string correspond to an attribute pair : Attribute=Value
-		*/
-		std::vector<std::string> GetFormattedContent() const;
-
 	private:
 		void RegisterPair(const std::string& p_key, const std::string& p_value);
 		void RegisterPair(const AttributePair& p_pair);
 
 		void Load();
 
-		AttributePair	ExtractKeyAndValue(const std::string& p_attributeLine)	const;
-		bool			IsValidLine(const std::string& p_attributeLine)	const;
-		bool			StringToBoolean(const std::string& p_value)			const;
-
 	private:
-		std::string		m_filePath;
-		AttributeMap	m_data;
+		std::string m_filePath;
+		AttributeMap m_data;
 	};
 }
 

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
@@ -12,51 +12,39 @@
 
 namespace OvTools::Filesystem
 {
-	template<typename T>
+	template<SupportedIniType T>
 	inline T IniFile::Get(const std::string& p_key)
 	{
-		if constexpr (std::is_same<bool, T>::value)
+		if (!IsKeyExisting(p_key))
 		{
-			if (!IsKeyExisting(p_key))
-				return false;
-
-			return StringToBoolean(m_data[p_key]);
+			return T{};
 		}
-		else if constexpr (std::is_same<std::string, T>::value)
-		{
-			if (!IsKeyExisting(p_key))
-				return std::string("NULL");
 
+		if constexpr (std::same_as<T, bool>)
+		{
+			return m_data[p_key] == "1" || m_data[p_key] == "T" || m_data[p_key] == "t" || m_data[p_key] == "True" || m_data[p_key] == "true";
+		}
+		else if constexpr (std::same_as<T, std::string>)
+		{
 			return m_data[p_key];
 		}
-		else if constexpr (std::is_integral<T>::value)
+		else if constexpr (std::integral<T>)
 		{
-			if (!IsKeyExisting(p_key))
-				return static_cast<T>(0);
-
 			return static_cast<T>(std::atoi(m_data[p_key].c_str()));
 		}
-		else if constexpr (std::is_floating_point<T>::value)
+		else if constexpr (std::floating_point<T>)
 		{
-			if (!IsKeyExisting(p_key))
-				return static_cast<T>(0.0f);
-
 			return static_cast<T>(std::atof(m_data[p_key].c_str()));
-		}
-		else
-		{
-			static_assert(false, "The given type must be : bool, integral, floating point or string");
-			return T();
 		}
 	}
 
-	template<typename T>
+	template<SupportedIniType T>
 	inline T IniFile::GetOrDefault(const std::string& p_key, T p_default)
 	{
 		return IsKeyExisting(p_key) ? Get<T>(p_key) : p_default;
 	}
 
-	template<typename T>
+	template<SupportedIniType T>
 	inline bool IniFile::TryGet(const std::string& p_key, T& p_outValue)
 	{
 		if (IsKeyExisting(p_key))
@@ -68,30 +56,22 @@ namespace OvTools::Filesystem
 		return false;
 	}
 
-	template<typename T>
+	template<SupportedIniType T>
 	inline bool IniFile::Set(const std::string& p_key, const T& p_value)
 	{
 		if (IsKeyExisting(p_key))
 		{
-			if constexpr (std::is_same<bool, T>::value)
+			if constexpr (std::same_as<T, bool>)
 			{
 				m_data[p_key] = p_value ? "true" : "false";
 			}
-			else if constexpr (std::is_same<std::string, T>::value)
+			else if constexpr (std::same_as<T, std::string>)
 			{
 				m_data[p_key] = p_value;
 			}
-			else if constexpr (std::is_integral<T>::value)
-			{
-				m_data[p_key] = std::to_string(p_value);
-			}
-			else if constexpr (std::is_floating_point<T>::value)
-			{
-				m_data[p_key] = std::to_string(p_value);
-			}
 			else
 			{
-				static_assert(false, "The given type must be : bool, integral, floating point or string");
+				m_data[p_key] = std::to_string(p_value);
 			}
 
 			return true;
@@ -100,8 +80,8 @@ namespace OvTools::Filesystem
 		return false;
 	}
 
-	template<typename T>
-	inline bool IniFile::Add(const std::string & p_key, const T & p_value)
+	template<SupportedIniType T>
+	inline bool IniFile::Add(const std::string& p_key, const T& p_value)
 	{
 		if (!IsKeyExisting(p_key))
 		{
@@ -113,17 +93,9 @@ namespace OvTools::Filesystem
 			{
 				RegisterPair(p_key, p_value);
 			}
-			else if constexpr (std::is_integral<T>::value)
-			{
-				RegisterPair(p_key, std::to_string(p_value));
-			}
-			else if constexpr (std::is_floating_point<T>::value)
-			{
-				RegisterPair(p_key, std::to_string(p_value));
-			}
 			else
 			{
-				static_assert(false, "The given type must be : bool, integral, floating point or std::string");
+				RegisterPair(p_key, std::to_string(p_value));
 			}
 
 			return true;


### PR DESCRIPTION
## Description
* Refactored `IniFile` to remove all `static_assert(false)` use cases.
* Also removed unused `GetFormattedContent()`.
* Moved utility functions from class to anonymous namespace
* Improved overall formatting


## Related Issues
Closes #404 