### PR TITLE
Fixed crash when no audio device is found

### DIFF
--- a/Sources/Overload/OvAudio/include/OvAudio/Core/AudioEngine.h
+++ b/Sources/Overload/OvAudio/include/OvAudio/Core/AudioEngine.h
@@ -33,6 +33,11 @@ namespace OvAudio::Core
 		~AudioEngine();
 
 		/**
+		* Returns true if the AudioEngine is valid (properly initialized and available)
+		*/
+		bool IsValid() const;
+
+		/**
 		* Update AudioSources and AudioListeners
 		*/
 		void Update();

--- a/Sources/Overload/OvAudio/src/OvAudio/Core/AudioPlayer.cpp
+++ b/Sources/Overload/OvAudio/src/OvAudio/Core/AudioPlayer.cpp
@@ -16,6 +16,12 @@ std::unique_ptr<OvAudio::Tracking::SoundTracker> OvAudio::Core::AudioPlayer::Pla
 {
 	std::unique_ptr<Tracking::SoundTracker> result;
 
+	if (!m_audioEngine.IsValid())
+	{
+		OVLOG_WARNING("Unable to play \"" + p_sound.path + "\". Audio engine is not valid");
+		return result;
+	}
+
 	irrklang::ISound* sound = m_audioEngine.GetIrrklangEngine()->play2D((m_audioEngine.GetWorkingDirectory() + p_sound.path).c_str(), p_looped, p_autoPlay, p_track);
 
 	if (p_track)
@@ -32,6 +38,12 @@ std::unique_ptr<OvAudio::Tracking::SoundTracker> OvAudio::Core::AudioPlayer::Pla
 std::unique_ptr<OvAudio::Tracking::SoundTracker> OvAudio::Core::AudioPlayer::PlaySpatialSound(const Resources::Sound& p_sound, bool p_autoPlay, bool p_looped, const OvMaths::FVector3& p_position, bool p_track)
 {
 	std::unique_ptr<Tracking::SoundTracker> result;
+
+	if (!m_audioEngine.IsValid())
+	{
+		OVLOG_WARNING("Unable to play \"" + p_sound.path + "\". Audio engine is not valid");
+		return result;
+	}
 
 	irrklang::ISound* sound = m_audioEngine.GetIrrklangEngine()->play3D((m_audioEngine.GetWorkingDirectory() + p_sound.path).c_str(), reinterpret_cast<const irrklang::vec3df&>(p_position), p_looped, p_autoPlay, p_track);
 


### PR DESCRIPTION
## Description
Added validation to make sure the irrklang audio engine is successfully created. Otherwise, skip playing sounds and log warnings.

## Related Issues
Closes #405 

## Notes
I think the `AudioEngine` could benefit from a deeper rework (out of scope for this PR). The `AudioEngine` should update at runtime if a device becomes available.