### PR TITLE
Added contextual menu to hierarchy panel background

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -89,7 +89,7 @@ public:
 		texture = OvCore::Global::ServiceLocator::Get<OvCore::ResourceManagement::TextureManager>()[p_path];
 	}
 
-	virtual void Execute() override
+	virtual void Execute(OvUI::Plugins::EPluginExecutionContext p_context) override
 	{
 		if (ImGui::IsItemHovered())
 		{
@@ -158,10 +158,10 @@ public:
 		}
 	}
 
-	virtual void Execute() override
+	virtual void Execute(OvUI::Plugins::EPluginExecutionContext p_context) override
 	{
 		if (m_widgets.size() > 0)
-			OvUI::Plugins::ContextualMenu::Execute();
+			OvUI::Plugins::ContextualMenu::Execute(p_context);
 	}
 
 	virtual void DeleteItem() = 0;

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -85,10 +85,10 @@ public:
         OvEditor::Utils::ActorCreationMenu::GenerateActorCreationMenu(createActor, m_target, std::bind(&OvUI::Widgets::Layout::TreeNode::Open, &m_treeNode));
 	}
 
-	virtual void Execute() override
+	virtual void Execute(OvUI::Plugins::EPluginExecutionContext p_context) override
 	{
 		if (m_widgets.size() > 0)
-			OvUI::Plugins::ContextualMenu::Execute();
+			OvUI::Plugins::ContextualMenu::Execute(p_context);
 	}
 
 private:
@@ -191,7 +191,9 @@ OvEditor::Panels::Hierarchy::Hierarchy
 
 		p_element.first->DetachFromParent();
 	};
-    m_sceneRoot->AddPlugin<ActorContextualMenu>(nullptr, *m_sceneRoot);
+	m_sceneRoot->AddPlugin<ActorContextualMenu>(nullptr, *m_sceneRoot);
+
+	AddPlugin<ActorContextualMenu>(nullptr, *m_sceneRoot);
 
 	// TODO: This code is unsafe, if the hierarchy gets deleted before the last actor gets deleted, this might crash
 	EDITOR_EVENT(ActorUnselectedEvent) += std::bind(&Hierarchy::UnselectActorsWidgets, this);

--- a/Sources/Overload/OvUI/include/OvUI/Panels/APanel.h
+++ b/Sources/Overload/OvUI/include/OvUI/Panels/APanel.h
@@ -9,14 +9,15 @@
 #include <vector>
 #include <unordered_map>
 
-#include "OvUI/Internal/WidgetContainer.h"
+#include <OvUI/Internal/WidgetContainer.h>
+#include <OvUI/Plugins/Pluginable.h>
 
 namespace OvUI::Panels
 {
 	/**
 	* A Panel is a component of a canvas. It is a sort of window in the UI
 	*/
-	class APanel : public API::IDrawable, public Internal::WidgetContainer
+	class APanel : public API::IDrawable, public Plugins::Pluginable, public Internal::WidgetContainer
 	{
 	public:
 		/**

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/ContextualMenu.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/ContextualMenu.h
@@ -22,8 +22,9 @@ namespace OvUI::Plugins
 	public:
 		/**
 		* Execute the plugin
+		* @param p_context
 		*/
-		void Execute();
+		void Execute(EPluginExecutionContext p_context);
 
 		/**
 		* Force close the contextual menu

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/DDSource.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/DDSource.h
@@ -39,8 +39,9 @@ namespace OvUI::Plugins
 
 		/**
 		* Execute the behaviour of the drag and drop source
+		* @param p_context
 		*/
-		virtual void Execute() override
+		virtual void Execute(EPluginExecutionContext p_context) override
 		{
 			ImGuiDragDropFlags src_flags = 0;
 			src_flags |= ImGuiDragDropFlags_SourceNoDisableHover;     // Keep the source displayed as hovered

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/DDTarget.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/DDTarget.h
@@ -32,9 +32,9 @@ namespace OvUI::Plugins
 
 		/**
 		* Execute the drag and drop target behaviour
-		* @param p_identifier
+		* @param p_context
 		*/
-		virtual void Execute() override
+		virtual void Execute(EPluginExecutionContext p_context) override
 		{
 			if (ImGui::BeginDragDropTarget())
 			{

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/DataDispatcher.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/DataDispatcher.h
@@ -85,8 +85,9 @@ namespace OvUI::Plugins
 
 		/**
 		* Execute the data dispatcher behaviour (No effect)
+		* @param p_context
 		*/
-		virtual void Execute() override {}
+		virtual void Execute(EPluginExecutionContext p_context) override {}
 
 	private:
 		bool m_valueChanged = false;

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/IPlugin.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/IPlugin.h
@@ -6,9 +6,17 @@
 
 #pragma once
 
-
 namespace OvUI::Plugins
 {
+	/**
+	* Context of execution for a plugin
+	*/
+	enum class EPluginExecutionContext
+	{
+		WIDGET,
+		PANEL
+	};
+
 	/**
 	* Interface to any plugin of OvUI.
 	* A plugin is basically a behaviour that you can plug to a widget
@@ -18,8 +26,9 @@ namespace OvUI::Plugins
 	public:
 		/**
 		* Execute the plugin behaviour
+		* @param p_context
 		*/
-		virtual void Execute() = 0;
+		virtual void Execute(EPluginExecutionContext p_context) = 0;
 
 		/* Feel free to store any data you want here */
 		void* userData = nullptr;

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/Pluginable.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/Pluginable.h
@@ -21,7 +21,7 @@ namespace OvUI::Plugins
 		/**
 		* Destructor (Destroys every plugins)
 		*/
-		~Pluginable()
+		virtual ~Pluginable()
 		{
 			RemoveAllPlugins();
 		}
@@ -61,10 +61,10 @@ namespace OvUI::Plugins
 		/**
 		* Execute every plugins
 		*/
-		void ExecutePlugins()
+		void ExecutePlugins(EPluginExecutionContext p_context)
 		{
 			for (auto& plugin : m_plugins)
-				plugin->Execute();
+				plugin->Execute(p_context);
 		}
 
 		/**

--- a/Sources/Overload/OvUI/src/OvUI/Panels/APanel.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/APanel.cpp
@@ -18,7 +18,9 @@ OvUI::Panels::APanel::APanel()
 void OvUI::Panels::APanel::Draw()
 {
 	if (enabled)
+	{
 		_Draw_Impl();
+	}
 }
 
 const std::string & OvUI::Panels::APanel::GetPanelID() const

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelWindow.cpp
@@ -173,6 +173,7 @@ void OvUI::Panels::PanelWindow::_Draw_Impl()
                 m_mustScrollToTop = false;
             }
 
+			ExecutePlugins(Plugins::EPluginExecutionContext::PANEL);
 			DrawWidgets();
 		}
 

--- a/Sources/Overload/OvUI/src/OvUI/Plugins/ContextualMenu.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Plugins/ContextualMenu.cpp
@@ -4,11 +4,12 @@
 * @licence: MIT
 */
 
-#include "OvUI/Plugins/ContextualMenu.h"
+#include <OvUI/Panels/APanel.h>
+#include <OvUI/Plugins/ContextualMenu.h>
 
-void OvUI::Plugins::ContextualMenu::Execute()
+void OvUI::Plugins::ContextualMenu::Execute(EPluginExecutionContext p_context)
 {
-	if (ImGui::BeginPopupContextItem())
+	if (p_context == EPluginExecutionContext::PANEL ? ImGui::BeginPopupContextWindow() : ImGui::BeginPopupContextItem())
 	{
 		DrawWidgets();
 		ImGui::EndPopup();

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
@@ -50,7 +50,7 @@ void OvUI::Widgets::AWidget::Draw()
 		_Draw_Impl();
 
 		if (m_autoExecutePlugins)
-			ExecutePlugins();
+			ExecutePlugins(Plugins::EPluginExecutionContext::WIDGET);
 
 		if (!lineBreak)
 			ImGui::SameLine();

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
@@ -70,7 +70,7 @@ void OvUI::Widgets::Layout::TreeNode::_Draw_Impl()
 
 		m_opened = true;
 
-		ExecutePlugins(); // Manually execute plugins to make plugins considering the TreeNode and no childs
+		ExecutePlugins(Plugins::EPluginExecutionContext::WIDGET); // Manually execute plugins to make plugins considering the TreeNode and no childs
 
 		DrawWidgets();
 
@@ -83,6 +83,6 @@ void OvUI::Widgets::Layout::TreeNode::_Draw_Impl()
 
 		m_opened = false;
 
-		ExecutePlugins(); // Manually execute plugins to make plugins considering the TreeNode and no childs
+		ExecutePlugins(Plugins::EPluginExecutionContext::WIDGET); // Manually execute plugins to make plugins considering the TreeNode and no childs
 	}
 }


### PR DESCRIPTION
## Description
Added contextual menu when right-clicking on the hierarchy panel background.
This allows for actor creation without having to click on the "Root" object.

* `APanel` are now `Pluginable`
* Added a `EPluginExecutionContext` enum, so one plugin can have multiple implementations for each context:
  * Windows = panels
  * Items = Widgets

## Related Issues
Fixes #361

## Screenshots

https://github.com/user-attachments/assets/a567f09c-13cc-460d-a9fd-d41dab0dab5a


![image](https://github.com/user-attachments/assets/fa34417e-f2a2-497f-85c8-592b11777081)

