### PR TITLE
Removed fake root actor

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
@@ -84,8 +84,6 @@ namespace OvEditor::Panels
 		OvTools::Eventing::Event<OvCore::ECS::Actor&> ActorUnselectedEvent;
 
 	private:
-		OvUI::Widgets::Layout::TreeNode* m_sceneRoot;
-
 		std::unordered_map<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> m_widgetActorLink;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Plugins/DDTarget.h
+++ b/Sources/Overload/OvUI/include/OvUI/Plugins/DDTarget.h
@@ -10,9 +10,9 @@
 
 #include <OvTools/Eventing/Event.h>
 
-#include "OvUI/ImGui/imgui.h"
-
-#include "OvUI/Plugins/IPlugin.h"
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/ImGui/imgui_internal.h>
+#include <OvUI/Plugins/IPlugin.h>
 
 namespace OvUI::Plugins
 {
@@ -36,7 +36,15 @@ namespace OvUI::Plugins
 		*/
 		virtual void Execute(EPluginExecutionContext p_context) override
 		{
-			if (ImGui::BeginDragDropTarget())
+			const bool result =
+				p_context == EPluginExecutionContext::WIDGET ?
+				ImGui::BeginDragDropTarget() :
+				ImGui::BeginDragDropTargetCustom(
+					ImGui::GetCurrentWindow()->WorkRect,
+					ImGui::GetID(identifier.c_str())
+				);
+
+			if (result)
 			{
 				if (!m_isHovered)
 					HoverStartEvent.Invoke();

--- a/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Internal/WidgetContainer.cpp
@@ -5,6 +5,7 @@
 */
 
 #include <algorithm>
+#include <span>
 
 #include "OvUI/Internal/WidgetContainer.h"
 
@@ -77,16 +78,31 @@ void OvUI::Internal::WidgetContainer::DrawWidgets()
 {
 	CollectGarbages();
 
-    if (m_reversedDrawOrder)
-    {
-        for (auto it = m_widgets.crbegin(); it != m_widgets.crend(); ++it)
-            it->first->Draw();
-    }
-    else
-    {
-        for (const auto& widget : m_widgets)
-            widget.first->Draw();
-    }
+	std::vector<OvUI::Widgets::AWidget*> widgetsToDraw;
+	widgetsToDraw.reserve(m_widgets.size());
+
+	// We copy the widgets to draw in a separate vector to avoid issues when a widget is
+	// added/destroyed during the draw process, which would invalidate the iterator.
+	// This is especially useful to allow plugins to add and remove widgets during the draw process.
+	for (const auto& widgetPair : m_widgets)
+	{
+		widgetsToDraw.push_back(widgetPair.first);
+	}
+
+	if (m_reversedDrawOrder)
+	{
+		for (auto it = widgetsToDraw.rbegin(); it != widgetsToDraw.rend(); ++it)
+		{
+			(*it)->Draw();
+		}
+	}
+	else
+	{
+		for (const auto& widget : widgetsToDraw)
+		{
+			widget->Draw();
+		}
+	}
 }
 
 void OvUI::Internal::WidgetContainer::ReverseDrawOrder(const bool reversed)


### PR DESCRIPTION
## Description
Removed the fake "Root" actor in the editor's hierarchy, which was only there because panels (windows) didn't support drag-and-drop, so we had to have this fake root actor to provide a way to detach an actor from its parent.

## Screenshots
![image](https://github.com/user-attachments/assets/66870b23-ac7a-4309-bc71-3041b80e5397)

https://github.com/user-attachments/assets/888509f9-de19-4792-a78e-569becb6821e

