### PR TITLE
Editor Theme Selection & Theme System Rework

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <OvTools/Eventing/Event.h>
+#include <OvUI/Styling/EStyle.h>
 
 namespace OvEditor::Settings
 {
@@ -92,5 +93,6 @@ namespace OvEditor::Settings
 		inline static Property<float> TranslationSnapUnit = { 1.0f };
 		inline static Property<float> RotationSnapUnit = { 15.0f };
 		inline static Property<float> ScalingSnapUnit = { 1.0f };
+		inline static Property<int> ColorTheme = { static_cast<int>(OvUI::Styling::EStyle::DEFAULT_DARK) };
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 
+#include <OvEditor/Settings/EditorSettings.h>
 #include <OvRendering/Entities/Light.h>
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvTools/Utils/SystemCalls.h>
@@ -113,7 +114,9 @@ OvEditor::Core::Context::Context(const std::string& p_projectPath, const std::st
 
 	std::filesystem::create_directories(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\");
 
-	uiManager = std::make_unique<OvUI::Core::UIManager>(window->GetGlfwWindow(), OvUI::Styling::EStyle::ALTERNATIVE_DARK);
+	uiManager = std::make_unique<OvUI::Core::UIManager>(window->GetGlfwWindow(),
+		static_cast<OvUI::Styling::EStyle>(OvEditor::Settings::EditorSettings::ColorTheme.Get())
+	);
 	uiManager->LoadFont("Ruda_Big", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 16);
 	uiManager->LoadFont("Ruda_Small", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 12);
 	uiManager->LoadFont("Ruda_Medium", editorAssetsPath + "\\Fonts\\Ruda-Bold.ttf", 14);

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -36,7 +36,6 @@ OvEditor::Core::Editor::Editor(Context& p_context) :
 	m_panelsManager(m_canvas),
 	m_editorActions(m_context, m_panelsManager)
 {
-	Settings::EditorSettings::Load();
 	SetupUI();
 
 	m_context.sceneManager.LoadDefaultScene();

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
@@ -9,22 +9,23 @@
 #include <filesystem>
 #include <fstream>
 
-#include "OvEditor/Core/ProjectHub.h"
-
-#include <OvUI/Widgets/Texts/Text.h>
-#include <OvUI/Widgets/Visual/Separator.h>
-#include <OvUI/Widgets/Layout/Columns.h>
-#include <OvUI/Widgets/Layout/Spacing.h>
-#include <OvUI/Widgets/Layout/Group.h>
-#include <OvUI/Widgets/Buttons/Button.h>
-#include <OvUI/Widgets/InputFields/InputText.h>
+#include <OvEditor/Core/ProjectHub.h>
+#include <OvEditor/Settings/EditorSettings.h>
 
 #include <OvTools/Utils/PathParser.h>
 #include <OvTools/Utils/SystemCalls.h>
 
-#include <OvWindowing/Dialogs/SaveFileDialog.h>
-#include <OvWindowing/Dialogs/OpenFileDialog.h>
+#include <OvUI/Widgets/Buttons/Button.h>
+#include <OvUI/Widgets/InputFields/InputText.h>
+#include <OvUI/Widgets/Layout/Columns.h>
+#include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/Layout/Spacing.h>
+#include <OvUI/Widgets/Texts/Text.h>
+#include <OvUI/Widgets/Visual/Separator.h>
+
 #include <OvWindowing/Dialogs/MessageBox.h>
+#include <OvWindowing/Dialogs/OpenFileDialog.h>
+#include <OvWindowing/Dialogs/SaveFileDialog.h>
 
 #define PROJECTS_FILE std::string(OvTools::Utils::SystemCalls::GetPathToAppdata() + "\\OverloadTech\\OvEditor\\projects.ini")
 
@@ -296,7 +297,9 @@ void OvEditor::Core::ProjectHub::SetupContext()
 	/* Graphics context creation */
 	m_driver = std::make_unique<OvRendering::Context::Driver>(OvRendering::Settings::DriverSettings{ false });
 
-	m_uiManager = std::make_unique<OvUI::Core::UIManager>(m_window->GetGlfwWindow(), OvUI::Styling::EStyle::ALTERNATIVE_DARK);
+	m_uiManager = std::make_unique<OvUI::Core::UIManager>(m_window->GetGlfwWindow(),
+		static_cast<OvUI::Styling::EStyle>(OvEditor::Settings::EditorSettings::ColorTheme.Get())
+	);
 	m_uiManager->LoadFont("Ruda_Big", "Data\\Editor\\Fonts\\Ruda-Bold.ttf", 18);
 	m_uiManager->UseFont("Ruda_Big");
 	m_uiManager->EnableEditorLayoutSave(false);

--- a/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Main.cpp
@@ -6,12 +6,13 @@
 
 #include <filesystem>
 
-#include <OvTools/Utils/String.h>
+#include <OvEditor/Core/Application.h>
+#include <OvEditor/Core/ProjectHub.h>
+#include <OvEditor/Settings/EditorSettings.h>
 
 #include <OvRendering/Utils/Defines.h>
 
-#include "OvEditor/Core/Application.h"
-#include "OvEditor/Core/ProjectHub.h"
+#include <OvTools/Utils/String.h>
 
 #undef APIENTRY
 #include "Windows.h"
@@ -44,6 +45,8 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PSTR lpCmdLine, INT nC
 int main(int argc, char** argv)
 {
 	UpdateWorkingDirectory(argv[0]);
+
+	OvEditor::Settings::EditorSettings::Load();
 
 	bool ready = false;
 	std::string projectPath;

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -23,6 +23,7 @@
 #include <OvUI/Widgets/Sliders/SliderFloat.h>
 #include <OvUI/Widgets/Drags/DragFloat.h>
 #include <OvUI/Widgets/Selection/ColorEdit.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
 
 #include "OvEditor/Panels/MenuBar.h"
 #include "OvEditor/Panels/SceneView.h"
@@ -69,6 +70,24 @@ void OvEditor::Panels::MenuBar::HandleShortcuts(float p_deltaTime)
 
 void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 {
+	auto& themeButton = m_settingsMenu->CreateWidget<MenuList>("Editor Theme");
+	themeButton.CreateWidget<Texts::Text>("Some themes may require a restart");
+
+	auto& colorTheme = themeButton.CreateWidget<Selection::ComboBox>(static_cast<int>(Settings::EditorSettings::ColorTheme.Get()));
+	colorTheme.choices = {
+		{ static_cast<int>(OvUI::Styling::EStyle::IM_CLASSIC_STYLE), "ImGui Classic"},
+		{ static_cast<int>(OvUI::Styling::EStyle::IM_DARK_STYLE), "ImGui Dark"},
+		{ static_cast<int>(OvUI::Styling::EStyle::IM_LIGHT_STYLE), "ImGui Light"},
+		{ static_cast<int>(OvUI::Styling::EStyle::DUNE_DARK), "Dune Dark"},
+		{ static_cast<int>(OvUI::Styling::EStyle::DEFAULT_DARK), "Alternative Dark"},
+		{ static_cast<int>(OvUI::Styling::EStyle::EVEN_DARKER), "Even Darker"}
+	};
+	colorTheme.ValueChangedEvent += [this](int p_value)
+	{
+		Settings::EditorSettings::ColorTheme = p_value;
+		EDITOR_CONTEXT(uiManager)->ApplyStyle(static_cast<OvUI::Styling::EStyle>(p_value));
+	};
+
 	m_settingsMenu->CreateWidget<MenuItem>("Spawn actors at origin", "", true, true).ValueChangedEvent += EDITOR_BIND(SetActorSpawnAtOrigin, std::placeholders::_1);
 	m_settingsMenu->CreateWidget<MenuItem>("Vertical Synchronization", "", true, true).ValueChangedEvent += [this](bool p_value) { EDITOR_CONTEXT(device)->SetVsync(p_value); };
 	auto& cameraSpeedMenu = m_settingsMenu->CreateWidget<MenuList>("Camera Speed");

--- a/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
@@ -42,6 +42,7 @@ void OvEditor::Settings::EditorSettings::Save()
 	iniFile.Add("translation_snap_unit", TranslationSnapUnit.Get());
 	iniFile.Add("rotation_snap_unit", RotationSnapUnit.Get());
 	iniFile.Add("scaling_snap_unit", ScalingSnapUnit.Get());
+	iniFile.Add("color_theme", ColorTheme.Get());
 	iniFile.Rewrite();
 }
 
@@ -57,4 +58,5 @@ void OvEditor::Settings::EditorSettings::Load()
 	LoadIniEntry<float>(iniFile, "translation_snap_unit", TranslationSnapUnit);
 	LoadIniEntry<float>(iniFile, "rotation_snap_unit", RotationSnapUnit);
 	LoadIniEntry<float>(iniFile, "scaling_snap_unit", ScalingSnapUnit);
+	LoadIniEntry<int>(iniFile, "color_theme", ColorTheme);
 }

--- a/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
@@ -110,7 +110,7 @@ OvGame::Core::Context::Context() :
 		basePSO
 	});
 
-	uiManager = std::make_unique<OvUI::Core::UIManager>(window->GetGlfwWindow(), OvUI::Styling::EStyle::ALTERNATIVE_DARK);
+	uiManager = std::make_unique<OvUI::Core::UIManager>(window->GetGlfwWindow(), OvUI::Styling::EStyle::DEFAULT_DARK);
 	uiManager->LoadFont("Ruda_Big", engineAssetsPath + "Fonts\\Ruda-Bold.ttf", 16);
 	uiManager->LoadFont("Ruda_Small", engineAssetsPath + "Fonts\\Ruda-Bold.ttf", 12);
 	uiManager->LoadFont("Ruda_Medium", engineAssetsPath + "Fonts\\Ruda-Bold.ttf", 14);

--- a/Sources/Overload/OvUI/include/OvUI/Styling/EStyle.h
+++ b/Sources/Overload/OvUI/include/OvUI/Styling/EStyle.h
@@ -17,6 +17,7 @@ namespace OvUI::Styling
 		IM_DARK_STYLE,
 		IM_LIGHT_STYLE,
 		DUNE_DARK,			// https://www.unknowncheats.me/forum/direct3d/189635-imgui-style-settings.html
-        ALTERNATIVE_DARK
+		DEFAULT_DARK,
+		EVEN_DARKER
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Styling/TStyle.h
+++ b/Sources/Overload/OvUI/include/OvUI/Styling/TStyle.h
@@ -1,0 +1,27 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <OvUI/Styling/EStyle.h>
+
+struct ImGuiStyle;
+
+namespace OvUI::Styling
+{
+	/**
+	* Base class (no actual inheritence, but rather a template specialization) for any style
+	*/
+	template<EStyle Style>
+	class TStyle
+	{
+	public:
+		/**
+		* Returns a pointer to the style struct.
+		*/
+		static ImGuiStyle GetStyle();
+	};
+}

--- a/Sources/Overload/OvUI/src/OvUI/Core/UIManager.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Core/UIManager.cpp
@@ -4,7 +4,29 @@
 * @licence: MIT
 */
 
-#include "OvUI/Core/UIManager.h"
+#include <OvUI/Core/UIManager.h>
+#include <OvUI/Styling/TStyle.h>
+
+namespace
+{
+	ImGuiStyle GetStyle(OvUI::Styling::EStyle p_style)
+	{
+		using namespace OvUI::Styling;
+		using enum OvUI::Styling::EStyle;
+
+		switch (p_style)
+		{
+		case IM_CLASSIC_STYLE: return TStyle<IM_CLASSIC_STYLE>::GetStyle();
+		case IM_DARK_STYLE: return TStyle<IM_DARK_STYLE>::GetStyle();
+		case IM_LIGHT_STYLE: return TStyle<IM_LIGHT_STYLE>::GetStyle();
+		case DUNE_DARK: return TStyle<DUNE_DARK>::GetStyle();
+		case DEFAULT_DARK: return TStyle<DEFAULT_DARK>::GetStyle();
+		case EVEN_DARKER: return TStyle<EVEN_DARKER>::GetStyle();
+		}
+
+		return ImGuiStyle();
+	}
+}
 
 OvUI::Core::UIManager::UIManager(GLFWwindow* p_glfwWindow, Styling::EStyle p_style, std::string_view p_glslVersion)
 {
@@ -28,144 +50,7 @@ OvUI::Core::UIManager::~UIManager()
 
 void OvUI::Core::UIManager::ApplyStyle(Styling::EStyle p_style)
 {
-	ImGuiStyle* style = &ImGui::GetStyle();
-
-	switch (p_style)
-	{
-	case OvUI::Styling::EStyle::IM_CLASSIC_STYLE:	ImGui::StyleColorsClassic();	break;
-	case OvUI::Styling::EStyle::IM_DARK_STYLE:		ImGui::StyleColorsDark();		break;
-	case OvUI::Styling::EStyle::IM_LIGHT_STYLE:		ImGui::StyleColorsLight();		break;
-	}
-
-	if (p_style == OvUI::Styling::EStyle::DUNE_DARK)
-	{
-		style->WindowPadding = ImVec2(15, 15);
-		style->WindowRounding = 5.0f;
-		style->FramePadding = ImVec2(5, 5);
-		style->FrameRounding = 4.0f;
-		style->ItemSpacing = ImVec2(12, 8);
-		style->ItemInnerSpacing = ImVec2(8, 6);
-		style->IndentSpacing = 25.0f;
-		style->ScrollbarSize = 15.0f;
-		style->ScrollbarRounding = 9.0f;
-		style->GrabMinSize = 5.0f;
-		style->GrabRounding = 3.0f;
-
-		style->Colors[ImGuiCol_Text] = ImVec4(0.80f, 0.80f, 0.83f, 1.00f);
-		style->Colors[ImGuiCol_TextDisabled] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-		style->Colors[ImGuiCol_WindowBg] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-		style->Colors[ImGuiCol_ChildBg] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
-		style->Colors[ImGuiCol_PopupBg] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
-		style->Colors[ImGuiCol_Border] = ImVec4(0.2f, 0.2f, 0.2f, 0.88f);
-		style->Colors[ImGuiCol_BorderShadow] = ImVec4(0.92f, 0.91f, 0.88f, 0.00f);
-		style->Colors[ImGuiCol_FrameBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-		style->Colors[ImGuiCol_FrameBgActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_TitleBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.3f, 0.3f, 0.3f, 0.75f);
-		style->Colors[ImGuiCol_TitleBgActive] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
-		style->Colors[ImGuiCol_MenuBarBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
-		style->Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-		style->Colors[ImGuiCol_CheckMark] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
-		style->Colors[ImGuiCol_SliderGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
-		style->Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-		style->Colors[ImGuiCol_Button] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_ButtonHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-		style->Colors[ImGuiCol_ButtonActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_Header] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
-		style->Colors[ImGuiCol_HeaderHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_HeaderActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-		style->Colors[ImGuiCol_Separator] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
-		style->Colors[ImGuiCol_SeparatorActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_ResizeGrip] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-		style->Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
-		style->Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
-		style->Colors[ImGuiCol_PlotLines] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
-		style->Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
-		style->Colors[ImGuiCol_PlotHistogram] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
-		style->Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
-		style->Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.25f, 1.00f, 0.00f, 0.43f);
-		style->Colors[ImGuiCol_ModalWindowDarkening] = ImVec4(1.00f, 0.98f, 0.95f, 0.73f);
-
-		style->Colors[ImGuiCol_Tab] = style->Colors[ImGuiCol_TabUnfocused];
-	}
-    else if (p_style == OvUI::Styling::EStyle::ALTERNATIVE_DARK)
-    {
-        style->WindowPadding = ImVec2(15, 15);
-        style->WindowRounding = 0.0f;
-        style->FramePadding = ImVec2(5, 5);
-        style->FrameRounding = 0.0f;
-        style->ItemSpacing = ImVec2(12, 8);
-        style->ItemInnerSpacing = ImVec2(8, 6);
-        style->IndentSpacing = 25.0f;
-        style->ScrollbarSize = 15.0f;
-        style->ScrollbarRounding = 0.0f;
-        style->GrabMinSize = 5.0f;
-        style->GrabRounding = 0.0f;
-        style->TabRounding = 0.0f;
-        style->ChildRounding = 0.0f;
-        style->PopupRounding = 0.0f;
-
-        style->WindowBorderSize = 1.0f;
-        style->FrameBorderSize = 0.0f;
-        style->PopupBorderSize = 1.0f;
-
-        ImVec4* colors = ImGui::GetStyle().Colors;
-        colors[ImGuiCol_Text] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
-        colors[ImGuiCol_TextDisabled] = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
-        colors[ImGuiCol_WindowBg] = ImVec4(0.09f, 0.09f, 0.10f, 1.00f);
-        colors[ImGuiCol_ChildBg] = ImVec4(0.09f, 0.09f, 0.10f, 1.00f);
-        colors[ImGuiCol_PopupBg] = ImVec4(0.06f, 0.06f, 0.07f, 1.00f);
-        colors[ImGuiCol_Border] = ImVec4(0.12f, 0.12f, 0.14f, 1.00f);
-        colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
-        colors[ImGuiCol_FrameBg] = ImVec4(0.12f, 0.12f, 0.13f, 1.00f);
-        colors[ImGuiCol_FrameBgHovered] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
-        colors[ImGuiCol_FrameBgActive] = ImVec4(0.27f, 0.27f, 0.29f, 1.00f);
-        colors[ImGuiCol_TitleBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
-        colors[ImGuiCol_TitleBgActive] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
-        colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
-        colors[ImGuiCol_MenuBarBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
-        colors[ImGuiCol_ScrollbarBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
-        colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.31f, 0.31f, 0.32f, 1.00f);
-        colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.41f, 0.41f, 0.42f, 1.00f);
-        colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.51f, 0.51f, 0.53f, 1.00f);
-        colors[ImGuiCol_CheckMark] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_SliderGrab] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_SliderGrabActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
-        colors[ImGuiCol_Button] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
-        colors[ImGuiCol_ButtonHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_ButtonActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
-        colors[ImGuiCol_Header] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
-        colors[ImGuiCol_HeaderHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_HeaderActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
-        colors[ImGuiCol_Separator] = ImVec4(1.00f, 1.00f, 1.00f, 0.20f);
-        colors[ImGuiCol_SeparatorHovered] = ImVec4(0.44f, 0.44f, 0.47f, 0.39f);
-        colors[ImGuiCol_SeparatorActive] = ImVec4(0.44f, 0.44f, 0.47f, 0.59f);
-        colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
-        colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
-        colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
-        colors[ImGuiCol_Tab] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
-        colors[ImGuiCol_TabHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_TabActive] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
-        colors[ImGuiCol_TabUnfocused] = ImVec4(0.20f, 0.20f, 0.22f, 0.39f);
-        colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.44f, 0.44f, 0.47f, 0.39f);
-        colors[ImGuiCol_DockingPreview] = ImVec4(0.91f, 0.62f, 0.00f, 0.78f);
-        colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.20f, 0.20f, 0.20f, 1.00f);
-        colors[ImGuiCol_PlotLines] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
-        colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
-        colors[ImGuiCol_PlotHistogram] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
-        colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
-        colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
-        colors[ImGuiCol_DragDropTarget] = ImVec4(0.91f, 0.62f, 0.00f, 1.00f);
-        colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
-        colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
-        colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
-        colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
-    }
+	ImGui::GetStyle() = GetStyle(p_style);
 }
 
 bool OvUI::Core::UIManager::LoadFont(const std::string& p_id, const std::string & p_path, float p_fontSize)

--- a/Sources/Overload/OvUI/src/OvUI/Styling/DefaultDark.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/DefaultDark.cpp
@@ -1,0 +1,86 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::DEFAULT_DARK>::GetStyle()
+{
+	ImGuiStyle style;
+
+	style.WindowPadding = ImVec2(15, 15);
+	style.WindowRounding = 0.0f;
+	style.FramePadding = ImVec2(5, 5);
+	style.FrameRounding = 0.0f;
+	style.ItemSpacing = ImVec2(12, 8);
+	style.ItemInnerSpacing = ImVec2(8, 6);
+	style.IndentSpacing = 25.0f;
+	style.ScrollbarSize = 15.0f;
+	style.ScrollbarRounding = 0.0f;
+	style.GrabMinSize = 5.0f;
+	style.GrabRounding = 0.0f;
+	style.TabRounding = 0.0f;
+	style.ChildRounding = 0.0f;
+	style.PopupRounding = 0.0f;
+
+	style.WindowBorderSize = 1.0f;
+	style.FrameBorderSize = 0.0f;
+	style.PopupBorderSize = 1.0f;
+
+	style.Colors[ImGuiCol_Text] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+	style.Colors[ImGuiCol_WindowBg] = ImVec4(0.09f, 0.09f, 0.10f, 1.00f);
+	style.Colors[ImGuiCol_ChildBg] = ImVec4(0.09f, 0.09f, 0.10f, 1.00f);
+	style.Colors[ImGuiCol_PopupBg] = ImVec4(0.06f, 0.06f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_Border] = ImVec4(0.12f, 0.12f, 0.14f, 1.00f);
+	style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+	style.Colors[ImGuiCol_FrameBg] = ImVec4(0.12f, 0.12f, 0.13f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.27f, 0.27f, 0.29f, 1.00f);
+	style.Colors[ImGuiCol_TitleBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.31f, 0.31f, 0.32f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.41f, 0.41f, 0.42f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.51f, 0.51f, 0.53f, 1.00f);
+	style.Colors[ImGuiCol_CheckMark] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
+	style.Colors[ImGuiCol_Button] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
+	style.Colors[ImGuiCol_Header] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
+	style.Colors[ImGuiCol_Separator] = ImVec4(1.00f, 1.00f, 1.00f, 0.20f);
+	style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.44f, 0.44f, 0.47f, 0.39f);
+	style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.44f, 0.44f, 0.47f, 0.59f);
+	style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_Tab] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_TabHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_TabActive] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_TabUnfocused] = ImVec4(0.20f, 0.20f, 0.22f, 0.39f);
+	style.Colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.44f, 0.44f, 0.47f, 0.39f);
+	style.Colors[ImGuiCol_DockingPreview] = ImVec4(0.91f, 0.62f, 0.00f, 0.78f);
+	style.Colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.20f, 0.20f, 0.20f, 1.00f);
+	style.Colors[ImGuiCol_PlotLines] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+	style.Colors[ImGuiCol_DragDropTarget] = ImVec4(0.91f, 0.62f, 0.00f, 1.00f);
+	style.Colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+	style.Colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+	style.Colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+	style.Colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+
+	return style;
+}

--- a/Sources/Overload/OvUI/src/OvUI/Styling/DuneDark.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/DuneDark.cpp
@@ -1,0 +1,70 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::DUNE_DARK>::GetStyle()
+{
+	ImGuiStyle style;
+	
+	style.WindowPadding = ImVec2(15, 15);
+	style.WindowRounding = 5.0f;
+	style.FramePadding = ImVec2(5, 5);
+	style.FrameRounding = 4.0f;
+	style.ItemSpacing = ImVec2(12, 8);
+	style.ItemInnerSpacing = ImVec2(8, 6);
+	style.IndentSpacing = 25.0f;
+	style.ScrollbarSize = 15.0f;
+	style.ScrollbarRounding = 9.0f;
+	style.GrabMinSize = 5.0f;
+	style.GrabRounding = 3.0f;
+
+	style.Colors[ImGuiCol_Text] = ImVec4(0.80f, 0.80f, 0.83f, 1.00f);
+	style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
+	style.Colors[ImGuiCol_WindowBg] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_ChildBg] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
+	style.Colors[ImGuiCol_PopupBg] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
+	style.Colors[ImGuiCol_Border] = ImVec4(0.2f, 0.2f, 0.2f, 0.88f);
+	style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.92f, 0.91f, 0.88f, 0.00f);
+	style.Colors[ImGuiCol_FrameBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_TitleBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.3f, 0.3f, 0.3f, 0.75f);
+	style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.07f, 0.07f, 0.09f, 1.00f);
+	style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
+	style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_CheckMark] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
+	style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.80f, 0.80f, 0.83f, 0.31f);
+	style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_Button] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
+	style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_Header] = ImVec4(0.10f, 0.09f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_Separator] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.24f, 0.23f, 0.29f, 1.00f);
+	style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+	style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.56f, 0.56f, 0.58f, 1.00f);
+	style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.06f, 0.05f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_PlotLines] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
+	style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
+	style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.40f, 0.39f, 0.38f, 0.63f);
+	style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.25f, 1.00f, 0.00f, 1.00f);
+	style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.25f, 1.00f, 0.00f, 0.43f);
+	style.Colors[ImGuiCol_ModalWindowDarkening] = ImVec4(1.00f, 0.98f, 0.95f, 0.73f);
+
+	style.Colors[ImGuiCol_Tab] = style.Colors[ImGuiCol_TabUnfocused];
+
+	return style;
+}

--- a/Sources/Overload/OvUI/src/OvUI/Styling/EvenDarker.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/EvenDarker.cpp
@@ -1,0 +1,86 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::EVEN_DARKER>::GetStyle()
+{
+	ImGuiStyle style;
+
+	style.WindowPadding = ImVec2(15, 15);
+	style.WindowRounding = 0.0f;
+	style.FramePadding = ImVec2(5, 5);
+	style.FrameRounding = 0.0f;
+	style.ItemSpacing = ImVec2(12, 8);
+	style.ItemInnerSpacing = ImVec2(8, 6);
+	style.IndentSpacing = 25.0f;
+	style.ScrollbarSize = 15.0f;
+	style.ScrollbarRounding = 0.0f;
+	style.GrabMinSize = 5.0f;
+	style.GrabRounding = 0.0f;
+	style.TabRounding = 0.0f;
+	style.ChildRounding = 0.0f;
+	style.PopupRounding = 0.0f;
+
+	style.WindowBorderSize = 1.0f;
+	style.FrameBorderSize = 0.0f;
+	style.PopupBorderSize = 1.0f;
+
+	style.Colors[ImGuiCol_Text] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_TextDisabled] = ImVec4(0.50f, 0.50f, 0.50f, 1.00f);
+	style.Colors[ImGuiCol_WindowBg] = ImVec4(0.03f, 0.04f, 0.05f, 1.00f);
+	style.Colors[ImGuiCol_ChildBg] = ImVec4(0.03f, 0.04f, 0.05f, 1.00f);
+	style.Colors[ImGuiCol_PopupBg] = ImVec4(0.03f, 0.04f, 0.05f, 1.00f);
+	style.Colors[ImGuiCol_Border] = ImVec4(0.06f, 0.07f, 0.08f, 1.00f);
+	style.Colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+	style.Colors[ImGuiCol_FrameBg] = ImVec4(0.12f, 0.12f, 0.13f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgHovered] = ImVec4(0.12f, 0.12f, 0.13f, 1.00f);
+	style.Colors[ImGuiCol_FrameBgActive] = ImVec4(0.12f, 0.12f, 0.13f, 1.00f);
+	style.Colors[ImGuiCol_TitleBg] = ImVec4(0.01f, 0.02f, 0.03f, 1.00f);
+	style.Colors[ImGuiCol_TitleBgActive] = ImVec4(0.01f, 0.02f, 0.03f, 1.00f);
+	style.Colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.01f, 0.02f, 0.03f, 1.00f);
+	style.Colors[ImGuiCol_MenuBarBg] = ImVec4(0.01f, 0.02f, 0.03f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarBg] = ImVec4(0.07f, 0.07f, 0.07f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.31f, 0.31f, 0.32f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.41f, 0.41f, 0.42f, 1.00f);
+	style.Colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.51f, 0.51f, 0.53f, 1.00f);
+	style.Colors[ImGuiCol_CheckMark] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_SliderGrab] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_SliderGrabActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
+	style.Colors[ImGuiCol_Button] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_ButtonHovered] = ImVec4(0.44f, 0.44f, 0.47f, 1.00f);
+	style.Colors[ImGuiCol_ButtonActive] = ImVec4(0.59f, 0.59f, 0.61f, 1.00f);
+	style.Colors[ImGuiCol_Header] = ImVec4(0.1f, 0.1f, 0.11f, 1.00f);
+	style.Colors[ImGuiCol_HeaderHovered] = ImVec4(0.15f, 0.15f, 0.17f, 1.00f);
+	style.Colors[ImGuiCol_HeaderActive] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_Separator] = ImVec4(1.00f, 1.00f, 1.00f, 0.20f);
+	style.Colors[ImGuiCol_SeparatorHovered] = ImVec4(0.44f, 0.44f, 0.47f, 0.39f);
+	style.Colors[ImGuiCol_SeparatorActive] = ImVec4(0.44f, 0.44f, 0.47f, 0.59f);
+	style.Colors[ImGuiCol_ResizeGrip] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_ResizeGripActive] = ImVec4(0.26f, 0.59f, 0.98f, 0.00f);
+	style.Colors[ImGuiCol_Tab] = ImVec4(0.1f, 0.1f, 0.11f, 1.00f);
+	style.Colors[ImGuiCol_TabHovered] = ImVec4(0.15f, 0.15f, 0.17f, 1.00f);
+	style.Colors[ImGuiCol_TabActive] = ImVec4(0.20f, 0.20f, 0.22f, 1.00f);
+	style.Colors[ImGuiCol_TabUnfocused] = ImVec4(0.1f, 0.1f, 0.11f, 1.00f);
+	style.Colors[ImGuiCol_TabUnfocusedActive] = ImVec4(0.15f, 0.15f, 0.17f, 1.00f);
+	style.Colors[ImGuiCol_DockingPreview] = ImVec4(0.91f, 0.62f, 0.00f, 0.78f);
+	style.Colors[ImGuiCol_DockingEmptyBg] = ImVec4(0.20f, 0.20f, 0.20f, 1.00f);
+	style.Colors[ImGuiCol_PlotLines] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_PlotLinesHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_PlotHistogram] = ImVec4(0.96f, 0.96f, 0.99f, 1.00f);
+	style.Colors[ImGuiCol_PlotHistogramHovered] = ImVec4(0.12f, 1.00f, 0.12f, 1.00f);
+	style.Colors[ImGuiCol_TextSelectedBg] = ImVec4(0.26f, 0.59f, 0.98f, 0.35f);
+	style.Colors[ImGuiCol_DragDropTarget] = ImVec4(0.91f, 0.62f, 0.00f, 1.00f);
+	style.Colors[ImGuiCol_NavHighlight] = ImVec4(0.26f, 0.59f, 0.98f, 1.00f);
+	style.Colors[ImGuiCol_NavWindowingHighlight] = ImVec4(1.00f, 1.00f, 1.00f, 0.70f);
+	style.Colors[ImGuiCol_NavWindowingDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.20f);
+	style.Colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.80f, 0.80f, 0.80f, 0.35f);
+
+	return style;
+}

--- a/Sources/Overload/OvUI/src/OvUI/Styling/ImClassic.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/ImClassic.cpp
@@ -1,0 +1,16 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::IM_CLASSIC_STYLE>::GetStyle()
+{
+	ImGuiStyle style;
+	ImGui::StyleColorsClassic(&style);
+	return style;
+}

--- a/Sources/Overload/OvUI/src/OvUI/Styling/ImDark.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/ImDark.cpp
@@ -1,0 +1,16 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::IM_DARK_STYLE>::GetStyle()
+{
+	ImGuiStyle style;
+	ImGui::StyleColorsDark(&style);
+	return style;
+}

--- a/Sources/Overload/OvUI/src/OvUI/Styling/ImLight.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Styling/ImLight.cpp
@@ -1,0 +1,16 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvUI/ImGui/imgui.h>
+#include <OvUI/Styling/TStyle.h>
+
+template<>
+ImGuiStyle OvUI::Styling::TStyle<OvUI::Styling::EStyle::IM_LIGHT_STYLE>::GetStyle()
+{
+	ImGuiStyle style;
+	ImGui::StyleColorsLight(&style);
+	return style;
+}


### PR DESCRIPTION
## Description
* Added theme selection through "menu bar > settings"
* Added currently selected theme to `EditorSettings`
* Changed `EditorSettings` load time to before `ProjectHub` starts, so both of them can use its content
* Moved the theme implementations outside of `UIManager`:
  * `TStyle` added, which can be implemented for each `EStyle`

## Screenshots
https://github.com/user-attachments/assets/f999f1a9-d1ea-45b7-a603-e051890f0366

