### PR TITLE
Editor lag on many logs

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -94,5 +94,6 @@ namespace OvEditor::Settings
 		inline static Property<float> RotationSnapUnit = { 15.0f };
 		inline static Property<float> ScalingSnapUnit = { 1.0f };
 		inline static Property<int> ColorTheme = { static_cast<int>(OvUI::Styling::EStyle::DEFAULT_DARK) };
+		inline static Property<int> ConsoleMaxLogs = { 500 };
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -86,13 +86,6 @@ void OvEditor::Core::Editor::PreUpdate()
 
 void OvEditor::Core::Editor::Update(float p_deltaTime)
 {
-	size_t msgPerFrame = 50;
-
-	for (size_t i = 0; i < msgPerFrame; i++)
-	{
-		OVLOG("Coucou");
-	}
-
 	HandleGlobalShortcuts();
 	UpdateCurrentEditorMode(p_deltaTime);
 	RenderViews(p_deltaTime);

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Editor.cpp
@@ -86,6 +86,13 @@ void OvEditor::Core::Editor::PreUpdate()
 
 void OvEditor::Core::Editor::Update(float p_deltaTime)
 {
+	size_t msgPerFrame = 50;
+
+	for (size_t i = 0; i < msgPerFrame; i++)
+	{
+		OVLOG("Coucou");
+	}
+
 	HandleGlobalShortcuts();
 	UpdateCurrentEditorMode(p_deltaTime);
 	RenderViews(p_deltaTime);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Console.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Console.cpp
@@ -13,6 +13,7 @@
 #include <OvUI/Widgets/Selection/CheckBox.h>
 #include <OvUI/Widgets/Visual/Separator.h>
 #include <OvUI/Widgets/Layout/Spacing.h>
+#include "OvEditor/Settings/EditorSettings.h"
 
 using namespace OvUI::Panels;
 using namespace OvUI::Widgets;
@@ -100,6 +101,11 @@ void OvEditor::Panels::Console::OnLogIntercepted(const OvDebug::LogData & p_logD
 	consoleItem1.enabled = IsAllowedByFilter(p_logData.logLevel);
 
 	m_logTextWidgets[&consoleItem1] = p_logData.logLevel;
+
+	if (m_logGroup->GetWidgets().size() > Settings::EditorSettings::ConsoleMaxLogs)
+	{
+		m_logGroup->RemoveWidget(*m_logGroup->GetWidgets().front().first);
+	}
 }
 
 void OvEditor::Panels::Console::ClearOnPlay()

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -165,6 +165,11 @@ void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 	debuggingMenu.CreateWidget<MenuItem>("Debug Frustum Culling", "", true, Settings::EditorSettings::DebugFrustumCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::DebugFrustumCulling = p_value; };
 	debuggingMenu.CreateWidget<MenuItem>("Editor Frustum Geometry Culling", "", true, Settings::EditorSettings::EditorFrustumGeometryCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::EditorFrustumGeometryCulling = p_value; };
 	debuggingMenu.CreateWidget<MenuItem>("Editor Frustum Light Culling", "", true, Settings::EditorSettings::EditorFrustumLightCulling).ValueChangedEvent += [this](bool p_value) { Settings::EditorSettings::EditorFrustumLightCulling = p_value; };
+	
+	auto& consoleSettingsMenu = m_settingsMenu->CreateWidget<MenuList>("Console Settings");
+	auto& consoleMaxLogsSlider = consoleSettingsMenu.CreateWidget<OvUI::Widgets::Sliders::SliderInt>(1, 1000, 500, OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Max Logs");
+	consoleMaxLogsSlider.ValueChangedEvent += [this](int p_value) { Settings::EditorSettings::ConsoleMaxLogs = p_value; };
+
 }
 
 void OvEditor::Panels::MenuBar::CreateFileMenu()


### PR DESCRIPTION
CLOSES #314

Having many messages in the console causes the editor to have frame drops.
Limited the amount of messages to a value that defaults at 500.
Users can change it in the menu bar -> Settings -> Console Settings -> Max Logs

Could serialize this data so user choices persists.