### PR TITLE
Updated msbuild.yml to run on main push, and ignore non-ready PRs

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -2,7 +2,7 @@ name: MSBuild
 
 on:
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: ready_for_review
   push:
     branches:
       - main

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -2,9 +2,10 @@ name: MSBuild
 
 on:
   pull_request:
+    types: [review_requested, ready_for_review]
   push:
     branches:
-      - develop
+      - main
 
 env:
   # Path to the solution file relative to the root of the project.


### PR DESCRIPTION
## Description
Updated msbuild.yml to run:
- when pushing to `main` (was `develop` before) main push
- and when a PR is ready (ignore draft)