### PR TITLE
Added shader variant (multi-compile) system

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -623,14 +623,9 @@ namespace
 				auto& shaderManager = OVSERVICE(OvCore::ResourceManagement::ShaderManager);
 				const std::string resourcePath = EDITOR_EXEC(GetResourcePath(filePath, m_protected));
 				const auto previousLoggingSettings = ShaderLoader::GetLoggingSettings();
-
-				ShaderLoader::SetLoggingSettings(ShaderLoader::LoggingSettings{
-					.summary = true,
-					.linkingErrors = true,
-					.linkingSuccess = false,
-					.compilationErrors = true,
-					.compilationSuccess = false
-				});
+				auto newLoggingSettings = previousLoggingSettings;
+				newLoggingSettings.summary = true; // Force enable summary logging
+				ShaderLoader::SetLoggingSettings(newLoggingSettings);
 
 				if (shaderManager.IsResourceRegistered(resourcePath))
 				{

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -618,11 +618,20 @@ namespace
 
 			auto& compileAction = CreateWidget<OvUI::Widgets::Menu::MenuItem>("Compile");
 
-			compileAction.ClickedEvent += [this]
-			{
+			compileAction.ClickedEvent += [this] {
+				using namespace OvRendering::Resources::Loaders;
 				auto& shaderManager = OVSERVICE(OvCore::ResourceManagement::ShaderManager);
 				const std::string resourcePath = EDITOR_EXEC(GetResourcePath(filePath, m_protected));
-				OvRendering::Resources::Loaders::ShaderLoader::SetLoggingSettings(true, true);
+				const auto previousLoggingSettings = ShaderLoader::GetLoggingSettings();
+
+				ShaderLoader::SetLoggingSettings(ShaderLoader::LoggingSettings{
+					.summary = true,
+					.linkingErrors = true,
+					.linkingSuccess = false,
+					.compilationErrors = true,
+					.compilationSuccess = false
+				});
+
 				if (shaderManager.IsResourceRegistered(resourcePath))
 				{
 					// Trying to recompile
@@ -631,13 +640,10 @@ namespace
 				else
 				{
 					// Trying to compile
-					auto shader = OVSERVICE(OvCore::ResourceManagement::ShaderManager)[resourcePath];
-					if (shader)
-					{
-						OVLOG_INFO("[COMPILE] \"" + filePath + "\": Success!");
-					}
+					OVSERVICE(OvCore::ResourceManagement::ShaderManager).LoadResource(resourcePath);
 				}
-				OvRendering::Resources::Loaders::ShaderLoader::SetLoggingSettings(false, false);
+
+				ShaderLoader::SetLoggingSettings(previousLoggingSettings);
 			};
 		}
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -622,6 +622,7 @@ namespace
 			{
 				auto& shaderManager = OVSERVICE(OvCore::ResourceManagement::ShaderManager);
 				const std::string resourcePath = EDITOR_EXEC(GetResourcePath(filePath, m_protected));
+				OvRendering::Resources::Loaders::ShaderLoader::SetLoggingSettings(true, true);
 				if (shaderManager.IsResourceRegistered(resourcePath))
 				{
 					// Trying to recompile
@@ -636,6 +637,7 @@ namespace
 						OVLOG_INFO("[COMPILE] \"" + filePath + "\": Success!");
 					}
 				}
+				OvRendering::Resources::Loaders::ShaderLoader::SetLoggingSettings(false, false);
 			};
 		}
 	};

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
@@ -23,11 +23,11 @@ namespace OvRendering::Resources::Loaders
 		*/
 		struct LoggingSettings
 		{
-			const bool summary : 1;
-			const bool linkingErrors : 1;
-			const bool linkingSuccess : 1;
-			const bool compilationErrors : 1;
-			const bool compilationSuccess : 1;
+			bool summary : 1;
+			bool linkingErrors : 1;
+			bool linkingSuccess : 1;
+			bool compilationErrors : 1;
+			bool compilationSuccess : 1;
 		};
 
 		using FilePathParserCallback = std::function<std::string(const std::string&)>;

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
@@ -8,7 +8,7 @@
 
 #include <functional>
 
-#include "OvRendering/Resources/Shader.h"
+#include <OvRendering/Resources/Shader.h>
 
 namespace OvRendering::Resources::Loaders
 {
@@ -23,11 +23,11 @@ namespace OvRendering::Resources::Loaders
 		*/
 		struct LoggingSettings
 		{
-			bool summary : 1;
-			bool linkingErrors : 1;
-			bool linkingSuccess : 1;
-			bool compilationErrors : 1;
-			bool compilationSuccess : 1;
+			const bool summary : 1;
+			const bool linkingErrors : 1;
+			const bool linkingSuccess : 1;
+			const bool compilationErrors : 1;
+			const bool compilationSuccess : 1;
 		};
 
 		using FilePathParserCallback = std::function<std::string(const std::string&)>;
@@ -43,20 +43,20 @@ namespace OvRendering::Resources::Loaders
 		static LoggingSettings GetLoggingSettings();
 
 		/**
-		* Enable or disable logging for errors and success
+		* Sets logging settings for the ShaderLoader
 		* @param p_settings
 		*/
 		static void SetLoggingSettings(LoggingSettings p_settings);
 
 		/**
-		* Create a shader
+		* Creates a shader from a file
 		* @param p_filePath
 		* @param p_pathParser
 		*/
 		static Shader* Create(const std::string& p_filePath, FilePathParserCallback p_pathParser = nullptr);
 
 		/**
-		* Create a shader from source
+		* Creates a shader from vertex and fragment source code
 		* @param p_vertexShader
 		* @param p_fragmentShader
 		* @note Doesn't support parsing (no include, no features)
@@ -64,14 +64,15 @@ namespace OvRendering::Resources::Loaders
 		static Shader* CreateFromSource(const std::string& p_vertexShader, const std::string& p_fragmentShader);
 
 		/**
-		* Recompile a shader
+		* Recompiles a shader
 		* @param p_shader
 		* @param p_filePath
+		* @param p_pathParser
 		*/
 		static void	Recompile(Shader& p_shader, const std::string& p_filePath, FilePathParserCallback p_pathParser = nullptr);
 
 		/**
-		* Destroy a shader
+		* Destroys a shader
 		* @param p_shader
 		*/
 		static bool Destroy(Shader*& p_shader);

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
@@ -18,6 +18,18 @@ namespace OvRendering::Resources::Loaders
 	class ShaderLoader
 	{
 	public:
+		/**
+		* Logging settings for the ShaderLoader
+		*/
+		struct LoggingSettings
+		{
+			bool summary : 1;
+			bool linkingErrors : 1;
+			bool linkingSuccess : 1;
+			bool compilationErrors : 1;
+			bool compilationSuccess : 1;
+		};
+
 		using FilePathParserCallback = std::function<std::string(const std::string&)>;
 
 		/**
@@ -26,11 +38,15 @@ namespace OvRendering::Resources::Loaders
 		ShaderLoader() = delete;
 
 		/**
-		* Enable or disable logging for errors and success
-		* @param p_logErrors
-		* @param p_logSuccess
+		* Returns the current logging settings
 		*/
-		static void SetLoggingSettings(bool p_logErrors, bool p_logSuccess);
+		static LoggingSettings GetLoggingSettings();
+
+		/**
+		* Enable or disable logging for errors and success
+		* @param p_settings
+		*/
+		static void SetLoggingSettings(LoggingSettings p_settings);
 
 		/**
 		* Create a shader

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
@@ -59,7 +59,7 @@ namespace OvRendering::Resources::Loaders
 		* Create a shader from source
 		* @param p_vertexShader
 		* @param p_fragmentShader
-		* @note Doesn't support path parsing/resolving
+		* @note Doesn't support parsing (no include, no features)
 		*/
 		static Shader* CreateFromSource(const std::string& p_vertexShader, const std::string& p_fragmentShader);
 

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/ShaderLoader.h
@@ -26,6 +26,13 @@ namespace OvRendering::Resources::Loaders
 		ShaderLoader() = delete;
 
 		/**
+		* Enable or disable logging for errors and success
+		* @param p_logErrors
+		* @param p_logSuccess
+		*/
+		static void SetLoggingSettings(bool p_logErrors, bool p_logSuccess);
+
+		/**
 		* Create a shader
 		* @param p_filePath
 		* @param p_pathParser

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
@@ -51,15 +51,19 @@ namespace OvRendering::Resources
 		*/
 		HAL::ShaderProgram& GetProgram(const FeatureSet& p_featureSet = {});
 
+		/**
+		* Returns supported features
+		*/
+		const FeatureSet& GetFeatures() const;
+
 	private:
 		Shader(
 			const std::string p_path,
-			const FeatureSet& p_features,
 			ProgramVariants&& p_programs
 		);
 
 		~Shader() = default;
-		void SetPrograms(const FeatureSet& p_features, ProgramVariants&& p_programs);
+		void SetPrograms(ProgramVariants&& p_programs);
 
 	public:
 		const std::string path;

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
@@ -8,6 +8,8 @@
 
 #include <string>
 #include <memory>
+#include <unordered_set>
+#include <unordered_map>
 
 #include <OvRendering/HAL/ShaderProgram.h>
 
@@ -24,20 +26,46 @@ namespace OvRendering::Resources
 		friend class Loaders::ShaderLoader;
 
 	public:
+		using FeatureSet = std::unordered_set<std::string>;
+
+		struct FeatureSetHash
+		{
+			size_t operator()(const FeatureSet& fs) const;
+		};
+
+		struct FeatureSetEqual
+		{
+			bool operator()(const FeatureSet& lhs, const FeatureSet& rhs) const;
+		};
+
+		using ProgramVariants = std::unordered_map<
+			FeatureSet,
+			std::unique_ptr<HAL::ShaderProgram>,
+			FeatureSetHash,
+			FeatureSetEqual
+		>;
+
 		/**
-		* Returns the associated shader program
+		* Returns the associated shader program for a given feature set
+		* @param p_featureSet (optional) The feature set to use. If not provided, the default program will be used.
 		*/
-		HAL::ShaderProgram& GetProgram() const;
+		HAL::ShaderProgram& GetProgram(const FeatureSet& p_featureSet = {});
 
 	private:
-		Shader(const std::string p_path, std::unique_ptr<HAL::ShaderProgram>&& p_program);
+		Shader(
+			const std::string p_path,
+			const FeatureSet& p_features,
+			ProgramVariants&& p_programs
+		);
+
 		~Shader() = default;
-		void SetProgram(std::unique_ptr<HAL::ShaderProgram>&& p_program);
+		void SetPrograms(const FeatureSet& p_features, ProgramVariants&& p_programs);
 
 	public:
 		const std::string path;
 
 	private:
-		std::unique_ptr<HAL::ShaderProgram> m_program;
+		FeatureSet m_features;
+		ProgramVariants m_programs;
 	};
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -51,14 +51,12 @@ namespace
 		.compilationSuccess = false,
 	};
 
-	// Load a shader, including any included files
 	struct ShaderLoadResult
 	{
 		const ShaderInputInfo inputInfo;
 		const std::string source;
 	};
 
-	// Parse the shader source code and extract the vertex and fragment shaders, as well as features
 	struct ShaderParseResult
 	{
 		const ShaderInputInfo inputInfo;
@@ -67,7 +65,6 @@ namespace
 		const OvRendering::Resources::Shader::FeatureSet features;
 	};
 
-	// Compile the shader and create a program for each combination of features
 	struct ShaderAssembleResult
 	{
 		const ShaderInputInfo inputInfo;
@@ -308,7 +305,14 @@ void main()
 		return std::nullopt;
 	}
 
-	ShaderLoadResult LoadShader(const ShaderInputInfo& p_shaderInputInfo, const std::string& p_filePath, OvRendering::Resources::Loaders::ShaderLoader::FilePathParserCallback p_pathParser)
+	/**
+	* Loads a shader file (ovfx) and its included files (ovfxh) recursively.
+	*/
+	ShaderLoadResult LoadShader(
+		const ShaderInputInfo& p_shaderInputInfo,
+		const std::string& p_filePath,
+		OvRendering::Resources::Loaders::ShaderLoader::FilePathParserCallback p_pathParser
+	)
 	{
 		std::ifstream file(p_filePath);
 
@@ -353,6 +357,9 @@ void main()
 		};
 	}
 
+	/**
+	* Parse the laoded shader code and extract the vertex and fragment shaders, as well as features
+	*/
 	ShaderParseResult ParseShader(const ShaderLoadResult& p_shaderLoadResult)
 	{
 		using namespace OvRendering::Settings;
@@ -405,6 +412,9 @@ void main()
 		};
 	}
 
+	/**
+	* Compile and create programs for each shader variant, and assemble them for a shader to use.
+	*/
 	ShaderAssembleResult AssembleShader(const ShaderParseResult& p_parseResult)
 	{
 		const auto variantCount = (size_t{ 1UL } << p_parseResult.features.size());
@@ -446,7 +456,7 @@ void main()
 			}
 		}
 
-		// If no default program was created, we create a default one
+		// If no default program was created, we create a default one (fallback)
 		if (!variants.contains({}))
 		{
 			variants.emplace(

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -53,7 +53,6 @@ namespace
 	struct ShaderAssembleResult
 	{
 		const uint32_t failures; // How many variants failed to compile
-		const OvRendering::Resources::Shader::FeatureSet features;
 		OvRendering::Resources::Shader::ProgramVariants variants;
 	};
 
@@ -438,7 +437,6 @@ void main()
 
 		return ShaderAssembleResult{
 			failures,
-			p_parseResult.features, // TODO: Exclude features that failed to compile
 			std::move(variants)
 		};
 	}
@@ -486,11 +484,7 @@ namespace OvRendering::Resources::Loaders
 
 		auto result = CompileShaderFromFile(p_filePath, p_pathParser);
 
-		return new Shader(
-			p_filePath,
-			result.features,
-			std::move(result.variants)
-		);
+		return new Shader(p_filePath, std::move(result.variants));
 	}
 
 	Shader* ShaderLoader::CreateFromSource(const std::string& p_vertexShader, const std::string& p_fragmentShader)
@@ -499,11 +493,7 @@ namespace OvRendering::Resources::Loaders
 
 		auto result = CompileShaderFromSources(p_vertexShader, p_fragmentShader);
 
-		return new Shader(
-			"",
-			result.features,
-			std::move(result.variants)
-		);
+		return new Shader({}, std::move(result.variants));
 	}
 
 	void ShaderLoader::Recompile(Shader& p_shader, const std::string& p_filePath, FilePathParserCallback p_pathParser)
@@ -514,10 +504,7 @@ namespace OvRendering::Resources::Loaders
 
 		if (result.failures == 0)
 		{
-			p_shader.SetPrograms(
-				result.features,
-				std::move(result.variants)
-			);
+			p_shader.SetPrograms(std::move(result.variants));
 		}
 		else
 		{

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -16,13 +16,13 @@
 #include <sstream>
 #include <unordered_set>
 
-#include <OvDebug/Logger.h>
 #include <OvDebug/Assertion.h>
+#include <OvDebug/Logger.h>
 
-#include <OvRendering/Resources/Loaders/ShaderLoader.h>
-#include <OvRendering/Resources/Shader.h>
 #include <OvRendering/HAL/ShaderProgram.h>
 #include <OvRendering/HAL/ShaderStage.h>
+#include <OvRendering/Resources/Loaders/ShaderLoader.h>
+#include <OvRendering/Resources/Shader.h>
 #include <OvRendering/Utils/ShaderUtil.h>
 
 namespace

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -87,11 +87,6 @@ namespace
 		std::optional<OvRendering::Settings::ShaderCompilationResult> compilationResult;
 	};
 
-	std::string GetShaderNameFromPath(const std::string& p_path)
-	{
-		return std::filesystem::path{ p_path }.stem().string();
-	}
-
 	std::string Trim(const std::string_view p_str)
 	{
 		auto view =
@@ -494,7 +489,7 @@ void main()
 	{
 		const auto shaderInputInfo = ShaderInputInfo{
 			.path = p_filePath,
-			.name = GetShaderNameFromPath(p_filePath)
+			.name = std::filesystem::path{ p_filePath }.stem().string()
 		};
 
 		const auto shaderLoadResult = LoadShader(shaderInputInfo, p_filePath, p_pathParser);

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -7,19 +7,58 @@
 #include <OvDebug/Assertion.h>
 #include <OvRendering/Resources/Shader.h>
 
-OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram() const
+namespace
 {
-	OVASSERT(m_program != nullptr, "Trying to access a null ShaderProgram");
-	return *m_program;
+	void ValidateProgramRegistry(const OvRendering::Resources::Shader::ProgramVariants& p_programs)
+	{
+		OVASSERT(p_programs.size() > 0 && p_programs.contains({}),
+			"Shader program registry must contain at least a default program"
+		);
+	}
 }
 
-OvRendering::Resources::Shader::Shader(const std::string p_path, std::unique_ptr<HAL::ShaderProgram>&& p_program) : path(p_path)
+size_t OvRendering::Resources::Shader::FeatureSetHash::operator()(const FeatureSet& fs) const
 {
-	SetProgram(std::move(p_program));
+	size_t hash = 0;
+
+	for (const auto& feature : fs)
+	{
+		hash ^= std::hash<std::string>{}(feature)+0x9e3779b9 + (hash << 6) + (hash >> 2);
+	}
+
+	return hash;
 }
 
-void OvRendering::Resources::Shader::SetProgram(std::unique_ptr<HAL::ShaderProgram>&& p_program)
+bool OvRendering::Resources::Shader::FeatureSetEqual::operator()(const FeatureSet& lhs, const FeatureSet& rhs) const
 {
-	OVASSERT(p_program != nullptr, "Cannot assign an invalid program!");
-	m_program = std::move(p_program);
+	return lhs == rhs;
+};
+
+OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram(const FeatureSet& p_featureSet)
+{
+	if (m_programs.contains(p_featureSet))
+	{
+		return *m_programs[p_featureSet];
+	}
+	else
+	{
+		OVASSERT(m_programs.contains({}), "No default program found for this shader");
+		return *m_programs[{}];
+	}
+}
+
+OvRendering::Resources::Shader::Shader(
+	const std::string p_path,
+	const FeatureSet& p_features,
+	ProgramVariants&& p_program
+) : path(p_path)
+{
+	SetPrograms(p_features, std::move(p_program));
+}
+
+void OvRendering::Resources::Shader::SetPrograms(const FeatureSet& p_features, ProgramVariants&& p_programs)
+{
+	ValidateProgramRegistry(p_programs);
+	m_features = p_features;
+	m_programs = std::move(p_programs);
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -47,18 +47,29 @@ OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram(cons
 	}
 }
 
+const OvRendering::Resources::Shader::FeatureSet& OvRendering::Resources::Shader::GetFeatures() const
+{
+	return m_features;
+}
+
 OvRendering::Resources::Shader::Shader(
 	const std::string p_path,
-	const FeatureSet& p_features,
 	ProgramVariants&& p_program
 ) : path(p_path)
 {
-	SetPrograms(p_features, std::move(p_program));
+	SetPrograms(std::move(p_program));
 }
 
-void OvRendering::Resources::Shader::SetPrograms(const FeatureSet& p_features, ProgramVariants&& p_programs)
+void OvRendering::Resources::Shader::SetPrograms(ProgramVariants&& p_programs)
 {
 	ValidateProgramRegistry(p_programs);
-	m_features = p_features;
 	m_programs = std::move(p_programs);
+
+	m_features.clear();
+
+	// Find all features based on the compiled programs
+	for (const auto& [key, _] : m_programs)
+	{
+		m_features.insert(key.begin(), key.end());
+	}
 }


### PR DESCRIPTION
## Description
- Added a system to create shader variants by using the keyword `#feature FEATURE_NAME` in a shader code.
Each possible variant gets compiled (2^n, with n being the feature count: how many times #feature is used in a single shader).
- Improved `#include` directive parsing by preventing commented includes (i.e. `// #include "...") from being evaluated. Instead of checking if a line "contains" a directive, we now trim the line, and checks if it starts with the directive (safer)
- Added a system to enable/disable logging for shader compilation, used by the `AssetBrowser` to enable logging temporarily (when a manual compilation is requested by the user).
- Updated shader compilation logging in editor to only display the shader name instead of the full path (easier to read output).

## Limitations
* This system only modifies `Shader` and `ShaderLoader` to enable the multi-compile feature. Some additional work needs to be done at the material level to expose these features in the editor, and use them when a material is bound.
* No support for "incompatible feature combinations" (to reduce variant count). Could be added further down the road as an optimization.
* Still no support for parsing shaders compiled from sources (not from file), so features cannot be resolved for these shaders (only used for the default fallback shader, so that's fine for now)
* Other pre-processor directives (like `#include`) cannot be added/excluded from a variant using `#ifdef`)

## Additional notes
The current system is similar to what unity describes as `shader_feature`:
https://docs.unity3d.com/Manual/SL-MultipleProgramVariants-declare.html