### PR TITLE
Exposed shader feature set to the material editor

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -40,64 +40,41 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 		tinyxml2::XMLNode* uniform = p_doc.NewElement("uniform");
 		uniformsNode->InsertEndChild(uniform);
 
-		const auto uniformInfo = m_shader->GetProgram().GetUniformInfo(name);
 		Serializer::SerializeString(p_doc, uniform, "name", name);
 
-		if (uniformInfo && !std::holds_alternative<std::monostate>(value))
+		if (!std::holds_alternative<std::monostate>(value))
 		{
 			auto visitor = [&](auto&& arg) {
 				using T = std::decay_t<decltype(arg)>;
 				using enum EUniformType;
-				const auto type = uniformInfo->type;
 
 				if constexpr (std::same_as<T, bool>)
 				{
-					if (type == BOOL)
-					{
-						Serializer::SerializeInt(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeInt(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, int>)
 				{
-					if (type == INT)
-					{
-						Serializer::SerializeInt(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeInt(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, float>)
 				{
-					if (type == FLOAT)
-					{
-						Serializer::SerializeFloat(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeFloat(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, FVector2>)
 				{
-					if (type == FLOAT_VEC2)
-					{
-						Serializer::SerializeVec2(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeVec2(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, FVector3>)
 				{
-					if (type == FLOAT_VEC3)
-					{
-						Serializer::SerializeVec3(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeVec3(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, FVector4>)
 				{
-					if (type == FLOAT_VEC4)
-					{
-						Serializer::SerializeVec4(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeVec4(p_doc, uniform, "value", arg);
 				}
 				else if constexpr (std::same_as<T, OvRendering::Resources::Texture*>)
 				{
-					if (type == SAMPLER_2D)
-					{
-						Serializer::SerializeTexture(p_doc, uniform, "value", arg);
-					}
+					Serializer::SerializeTexture(p_doc, uniform, "value", arg);
 				}
 				// No need to handle TextureHandle* here as it's not serializable (only texture assets are)
 			};
@@ -150,37 +127,59 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 		/* If the shader is valid, we set it to the material (Modify m_shader pointer + Query + FillUniforms) */
 		SetShader(shader);
 
-		tinyxml2::XMLNode* uniformsNode = p_node->FirstChildElement("uniforms"); // Access to "Uniforms" (Every uniform will be attached to "Uniforms")		
+		const auto uniformsNode = p_node->FirstChildElement("uniforms"); // Access to "Uniforms" (Every uniform will be attached to "Uniforms")		
 
 		if (uniformsNode)
 		{
-			/* We iterate over every <uniform>...</uniform> */
+			// Iterate over every <uniform>...</uniform>
 			for (auto uniform = uniformsNode->FirstChildElement("uniform"); uniform; uniform = uniform->NextSiblingElement("uniform"))
 			{
-				/* Verify that the uniform node contains a "name" element */
-				if (auto uniformNameElement = uniform->FirstChildElement("name"); uniformNameElement)
+				if (const auto uniformNameElement = uniform->FirstChildElement("name"))
 				{
-					const std::string uniformName = uniformNameElement->GetText();
+					const auto propName = uniformNameElement->GetText();
 
-					/* We collect information about the uniform (The uniform is identified in the shader by its name) */
-					const auto uniformInfo = m_shader->GetProgram().GetUniformInfo(uniformName);
-
-					/* We verify that the uniform is existant is the current shader */
-					if (uniformInfo)
+					// Make sure that there is a property with the same name.
+					// The type of the property value will be used to determine which type to deserialize.
+					// This means that the serialized data doesn't hold the type information, and if the
+					// type changes after serialization, it will not be deserialized correctly (skipped).
+					if (const auto prop = GetProperty(propName))
 					{
-						/* Deserialization of the uniform value depending on the uniform type (Deserialization result to std::any) */
-						switch (uniformInfo->type)
-						{
-							using enum OvRendering::Settings::EUniformType;
-							case BOOL: SetProperty(uniformInfo->name, Serializer::DeserializeBoolean(p_doc, uniform, "value")); break;
-							case INT: SetProperty(uniformInfo->name, Serializer::DeserializeInt(p_doc, uniform, "value")); break;
-							case FLOAT: SetProperty(uniformInfo->name, Serializer::DeserializeFloat(p_doc, uniform, "value")); break;
-							case FLOAT_VEC2: SetProperty(uniformInfo->name, Serializer::DeserializeVec2(p_doc, uniform, "value")); break;
-							case FLOAT_VEC3: SetProperty(uniformInfo->name, Serializer::DeserializeVec3(p_doc, uniform, "value")); break;
-							case FLOAT_VEC4: SetProperty(uniformInfo->name, Serializer::DeserializeVec4(p_doc, uniform, "value")); break;
-							case FLOAT_MAT4: SetProperty(uniformInfo->name, Serializer::DeserializeMat4(p_doc, uniform, "value")); break;
-							case SAMPLER_2D: SetProperty(uniformInfo->name, Serializer::DeserializeTexture(p_doc, uniform, "value")); break;
-						}
+						auto visitor = [&](auto&& arg) {
+							using T = std::decay_t<decltype(arg)>;
+							using namespace OvMaths;
+
+							if constexpr (std::same_as<T, bool>)
+							{
+								SetProperty(propName, Serializer::DeserializeBoolean(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, int>)
+							{
+								SetProperty(propName, Serializer::DeserializeInt(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, float>)
+							{
+								SetProperty(propName, Serializer::DeserializeFloat(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, FVector2>)
+							{
+								SetProperty(propName, Serializer::DeserializeVec2(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, FVector3>)
+							{
+								SetProperty(propName, Serializer::DeserializeVec3(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, FVector4>)
+							{
+								SetProperty(propName, Serializer::DeserializeVec4(p_doc, uniform, "value"));
+							}
+							else if constexpr (std::same_as<T, OvRendering::Resources::Texture*>)
+							{
+								SetProperty(propName, Serializer::DeserializeTexture(p_doc, uniform, "value"));
+							}
+							// No need to handle TextureHandle* here as it's not serializable (only texture assets are)
+						};
+
+						std::visit(visitor, prop->value);
 					}
 				}
 			}

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -42,45 +42,42 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 
 		Serializer::SerializeString(p_doc, uniform, "name", name);
 
-		if (!std::holds_alternative<std::monostate>(value))
-		{
-			auto visitor = [&](auto&& arg) {
-				using T = std::decay_t<decltype(arg)>;
-				using enum EUniformType;
+		auto visitor = [&](auto&& arg) {
+			using T = std::decay_t<decltype(arg)>;
+			using enum EUniformType;
 
-				if constexpr (std::same_as<T, bool>)
-				{
-					Serializer::SerializeInt(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, int>)
-				{
-					Serializer::SerializeInt(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, float>)
-				{
-					Serializer::SerializeFloat(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, FVector2>)
-				{
-					Serializer::SerializeVec2(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, FVector3>)
-				{
-					Serializer::SerializeVec3(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, FVector4>)
-				{
-					Serializer::SerializeVec4(p_doc, uniform, "value", arg);
-				}
-				else if constexpr (std::same_as<T, OvRendering::Resources::Texture*>)
-				{
-					Serializer::SerializeTexture(p_doc, uniform, "value", arg);
-				}
-				// No need to handle TextureHandle* here as it's not serializable (only texture assets are)
-			};
+			if constexpr (std::same_as<T, bool>)
+			{
+				Serializer::SerializeInt(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, int>)
+			{
+				Serializer::SerializeInt(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, float>)
+			{
+				Serializer::SerializeFloat(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, FVector2>)
+			{
+				Serializer::SerializeVec2(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, FVector3>)
+			{
+				Serializer::SerializeVec3(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, FVector4>)
+			{
+				Serializer::SerializeVec4(p_doc, uniform, "value", arg);
+			}
+			else if constexpr (std::same_as<T, OvRendering::Resources::Texture*>)
+			{
+				Serializer::SerializeTexture(p_doc, uniform, "value", arg);
+			}
+			// No need to handle TextureHandle* here as it's not serializable (only texture assets are)
+		};
 
-			std::visit(visitor, value);
-		}
+		std::visit(visitor, value);
 	}
 
 	std::string features;

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <sstream>
+
 #include <OvCore/Resources/Material.h>
 
 void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_node)
@@ -103,6 +105,20 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 			std::visit(visitor, value);
 		}
 	}
+
+	std::string features;
+
+	for (auto it = m_features.begin(); it != m_features.end(); ++it)
+	{
+		features += *it;
+
+		if (std::next(it) != m_features.end())
+		{
+			features += ",";
+		}
+	}
+
+	Serializer::SerializeString(p_doc, p_node, "features", features);
 }
 
 void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_node)
@@ -168,6 +184,19 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 					}
 				}
 			}
+		}
+	}
+
+	const auto features = Serializer::DeserializeString(p_doc, p_node, "features");
+
+	// Parse features (comma-separated)
+	std::string feature;
+	std::istringstream featureStream(features);
+	while (std::getline(featureStream, feature, ','))
+	{
+		if (!feature.empty())
+		{
+			AddFeature(feature);
 		}
 	}
 }

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/MaterialEditor.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/MaterialEditor.h
@@ -72,9 +72,11 @@ namespace OvEditor::Panels
 		void CreateShaderSelector();
 		void CreateMaterialSettings();
 		void CreateShaderSettings();
+		void CreateFeatureSettings();
 
 		void GenerateShaderSettingsContent();
 		void GenerateMaterialSettingsContent();
+		void GenerateMaterialFeaturesContent();
 
 	private:
 		OvCore::Resources::Material* m_target		= nullptr;
@@ -88,9 +90,11 @@ namespace OvEditor::Panels
 
 		OvUI::Widgets::Layout::Group* m_settings			= nullptr;
 		OvUI::Widgets::Layout::Group* m_materialSettings	= nullptr;
-		OvUI::Widgets::Layout::Group* m_shaderSettings		= nullptr;
+		OvUI::Widgets::Layout::Group* m_shaderSettings = nullptr;
+		OvUI::Widgets::Layout::Group* m_featureSettings = nullptr;
 
 		OvUI::Widgets::Layout::Columns<2>* m_shaderSettingsColumns = nullptr;
 		OvUI::Widgets::Layout::Columns<2>* m_materialSettingsColumns = nullptr;
+		OvUI::Widgets::Layout::Columns<2>* m_featureSettingsColumns = nullptr;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -24,78 +24,116 @@ using namespace OvUI::Panels;
 using namespace OvUI::Widgets;
 using namespace OvCore::Helpers;
 
-void DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
+namespace
 {
-	OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
-
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
-
-	auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
-	auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
-	xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
-	xyzWidget.lineBreak = false;
-
-	auto& rgbWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
-	auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-	rgbDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
-	rgbWidget.enabled = false;
-	rgbWidget.lineBreak = false;
-
-	auto& xyzButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
-	xyzButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-	xyzButton.lineBreak = false;
-
-	auto& rgbButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGB");
-	rgbButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-
-	xyzButton.ClickedEvent += [&]
+	std::string FormatPropertyName(const std::string& p_string)
 	{
-		xyzWidget.enabled = true;
+		std::string result;
+		std::string formattedInput = p_string;
+
+		if (formattedInput.rfind("u_", 0) == 0 || formattedInput.rfind("U_", 0) == 0)
+		{
+			formattedInput = formattedInput.substr(2);
+		}
+
+		std::string capsChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+		bool first = true;
+		bool capsNext = false;
+
+		for (char c : formattedInput)
+		{
+			if (first || capsNext)
+			{
+				c = toupper(c);
+				first = false;
+				capsNext = false;
+			}
+
+			if (c == '_')
+			{
+				c = ' ';
+				capsNext = true;
+			}
+
+			if (std::find(capsChars.begin(), capsChars.end(), c) != capsChars.end())
+				result.push_back(' ');
+
+			result.push_back(c);
+		}
+
+		return result;
+	}
+
+	void DrawHybridVec3(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector3& p_data, float p_step, float p_min, float p_max)
+	{
+		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
+
+		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+
+		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 3>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
+		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 3>>>();
+		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 3>&>(p_data));
+		xyzWidget.lineBreak = false;
+
+		auto& rgbWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(false, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z });
+		auto& rgbDispatcher = rgbWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
+		rgbDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
 		rgbWidget.enabled = false;
-	};
+		rgbWidget.lineBreak = false;
 
-	rgbButton.ClickedEvent += [&]
+		auto& xyzButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZ");
+		xyzButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+		xyzButton.lineBreak = false;
+
+		auto& rgbButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGB");
+		rgbButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+
+		xyzButton.ClickedEvent += [&] {
+			xyzWidget.enabled = true;
+			rgbWidget.enabled = false;
+		};
+
+		rgbButton.ClickedEvent += [&] {
+			xyzWidget.enabled = false;
+			rgbWidget.enabled = true;
+		};
+	}
+
+	void DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step, float p_min, float p_max)
 	{
-		xyzWidget.enabled = false;
-		rgbWidget.enabled = true;
-	};
-}
+		OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
 
-void DrawHybridVec4(OvUI::Internal::WidgetContainer& p_root, const std::string& p_name, OvMaths::FVector4& p_data, float p_step, float p_min, float p_max)
-{
-	OvCore::Helpers::GUIDrawer::CreateTitle(p_root, p_name);
+		auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
 
-	auto& rightSide = p_root.CreateWidget<OvUI::Widgets::Layout::Group>();
+		auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
+		auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
+		xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
+		xyzWidget.lineBreak = false;
 
-	auto& xyzWidget = rightSide.CreateWidget<OvUI::Widgets::Drags::DragMultipleScalars<float, 4>>(OvCore::Helpers::GUIDrawer::GetDataType<float>(), p_min, p_max, 0.f, p_step, "", OvCore::Helpers::GUIDrawer::GetFormat<float>());
-	auto& xyzDispatcher = xyzWidget.AddPlugin<OvUI::Plugins::DataDispatcher<std::array<float, 4>>>();
-	xyzDispatcher.RegisterReference(reinterpret_cast<std::array<float, 4>&>(p_data));
-	xyzWidget.lineBreak = false;
-
-	auto& rgbaWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
-	auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
-	rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
-	rgbaWidget.enabled = false;
-	rgbaWidget.lineBreak = false;
-
-	auto& xyzwButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
-	xyzwButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-	xyzwButton.lineBreak = false;
-
-	auto& rgbaButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGBA");
-	rgbaButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-
-	xyzwButton.ClickedEvent += [&]
-	{
-		xyzWidget.enabled = true;
+		auto& rgbaWidget = rightSide.CreateWidget<OvUI::Widgets::Selection::ColorEdit>(true, OvUI::Types::Color{ p_data.x, p_data.y, p_data.z, p_data.w });
+		auto& rgbaDispatcher = rgbaWidget.AddPlugin<OvUI::Plugins::DataDispatcher<OvUI::Types::Color>>();
+		rgbaDispatcher.RegisterReference(reinterpret_cast<OvUI::Types::Color&>(p_data));
 		rgbaWidget.enabled = false;
-	};
+		rgbaWidget.lineBreak = false;
 
-	rgbaButton.ClickedEvent += [&]
-	{
-		xyzWidget.enabled = false;
-		rgbaWidget.enabled = true;
-	};
+		auto& xyzwButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("XYZW");
+		xyzwButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+		xyzwButton.lineBreak = false;
+
+		auto& rgbaButton = rightSide.CreateWidget<OvUI::Widgets::Buttons::Button>("RGBA");
+		rgbaButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
+
+		xyzwButton.ClickedEvent += [&] {
+			xyzWidget.enabled = true;
+			rgbaWidget.enabled = false;
+		};
+
+		rgbaButton.ClickedEvent += [&] {
+			xyzWidget.enabled = false;
+			rgbaWidget.enabled = true;
+		};
+	}
 }
 
 OvEditor::Panels::MaterialEditor::MaterialEditor
@@ -275,45 +313,6 @@ void OvEditor::Panels::MaterialEditor::CreateFeatureSettings()
 	m_featureSettingsColumns->widths[0] = 150;
 }
 
-std::string UniformFormat(const std::string& p_string)
-{
-	std::string result;
-	std::string formattedInput = p_string;
-
-	if (formattedInput.rfind("u_", 0) == 0 || formattedInput.rfind("U_", 0) == 0)
-	{
-		formattedInput = formattedInput.substr(2);
-	}
-
-	std::string capsChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-	
-	bool first = true;
-	bool capsNext = false;
-
-	for (char c : formattedInput)
-	{
-		if (first || capsNext)
-		{
-			c = toupper(c);
-			first = false;
-			capsNext = false;
-		}
-
-		if (c == '_')
-		{
-			c = ' ';
-			capsNext = true;
-		}
-
-		if (std::find(capsChars.begin(), capsChars.end(), c) != capsChars.end())
-			result.push_back(' ');
-
-		result.push_back(c);
-	}
-
-	return result;
-}
-
 void OvEditor::Panels::MaterialEditor::GenerateShaderSettingsContent()
 {
 	using namespace OvRendering::Settings;
@@ -325,86 +324,81 @@ void OvEditor::Panels::MaterialEditor::GenerateShaderSettingsContent()
 		int,
 		std::pair<
 			std::string,
-			OvRendering::Data::MaterialPropertyType*
+			std::reference_wrapper<OvRendering::Data::MaterialPropertyType>
 		>
-	> sortedUniformsData;
+	> sortedProperties;
 
-	for (auto&[name, value] : m_target->GetProperties())
+	auto typeIndexVisitor = [&](auto& arg) -> uint32_t {
+		using T = std::decay_t<decltype(arg)>;
+
+		if constexpr (std::is_same_v<T, Texture*>) return 0;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector4>) return 1;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector3>) return 2;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector2>) return 3;
+		else if constexpr (std::is_same_v<T, float>) return 4;
+		else if constexpr (std::is_same_v<T, int>) return 5;
+		if constexpr (std::is_same_v<T, bool>) return 6;
+		return ~static_cast<uint32_t>(0UL);
+	};
+
+	for (auto&[name, prop] : m_target->GetProperties())
 	{
-		int orderID = 0;
-
-		auto uniformData = m_target->GetShader()->GetProgram().GetUniformInfo(name);
-
-		if (uniformData && name.length() > 0 && name[0] != '_') // Uniforms starting with '_' are internal (private), so not exposed
+		if (name.length() > 0 && name[0] != '_') // Uniforms starting with '_' are internal (private), so not exposed
 		{
-			switch (uniformData->type)
-			{
-			case EUniformType::SAMPLER_2D:	orderID = 0; break;
-			case EUniformType::FLOAT_VEC4:	orderID = 1; break;
-			case EUniformType::FLOAT_VEC3:	orderID = 2; break;
-			case EUniformType::FLOAT_VEC2:	orderID = 3; break;
-			case EUniformType::FLOAT:		orderID = 4; break;
-			case EUniformType::INT:			orderID = 5; break;
-			case EUniformType::BOOL:			orderID = 6; break;
-			}
-
-			sortedUniformsData.emplace(orderID, std::pair<std::string, OvRendering::Data::MaterialPropertyType*>{ name, & value.value });
+			const auto index = std::visit(typeIndexVisitor, prop.value);
+			sortedProperties.emplace(
+				index,
+				std::pair<std::string, std::reference_wrapper<OvRendering::Data::MaterialPropertyType>>{ 
+					name,
+					std::ref(prop.value)
+			});
 		}
 	}
 
-	for (auto& [order, info] : sortedUniformsData)
+	for (auto& [index, propInfo] : sortedProperties)
 	{
-		auto uniformData = m_target->GetShader()->GetProgram().GetUniformInfo(info.first);
+		const auto& name = propInfo.first;
+		auto& prop = propInfo.second.get();
 
-		if (uniformData)
-		{
-			const auto formattedType = UniformFormat(info.first);
+		const auto formattedType = FormatPropertyName(name);
 
-			// Create a visitor to handle each type in the variant
-			auto drawVisitor = [&](auto& arg) {
-				using T = std::decay_t<decltype(arg)>;
+		// Create a visitor to handle each type in the variant
+		auto drawVisitor = [&](auto& arg) {
+			using T = std::decay_t<decltype(arg)>;
 
-				if constexpr (std::is_same_v<T, bool>)
-				{
-					if (uniformData->type == EUniformType::BOOL)
-						GUIDrawer::DrawBoolean(*m_shaderSettingsColumns, formattedType, arg);
-				}
-				else if constexpr (std::is_same_v<T, int>)
-				{
-					if (uniformData->type == EUniformType::INT)
-						GUIDrawer::DrawScalar<int>(*m_shaderSettingsColumns, formattedType, arg);
-				}
-				else if constexpr (std::is_same_v<T, float>)
-				{
-					if (uniformData->type == EUniformType::FLOAT)
-						GUIDrawer::DrawScalar<float>(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-				}
-				else if constexpr (std::is_same_v<T, OvMaths::FVector2>)
-				{
-					if (uniformData->type == EUniformType::FLOAT_VEC2)
-						GUIDrawer::DrawVec2(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-				}
-				else if constexpr (std::is_same_v<T, OvMaths::FVector3>)
-				{
-					if (uniformData->type == EUniformType::FLOAT_VEC3)
-						DrawHybridVec3(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-				}
-				else if constexpr (std::is_same_v<T, OvMaths::FVector4>)
-				{
-					if (uniformData->type == EUniformType::FLOAT_VEC4)
-						DrawHybridVec4(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-				}
-				else if constexpr (std::is_same_v<T, Texture*>)
-				{
-					if (uniformData->type == EUniformType::SAMPLER_2D)
-						GUIDrawer::DrawTexture(*m_shaderSettingsColumns, formattedType, arg);
-				}
-				// No UI for TextureHandle* since it's not handled in the original code
-				};
+			if constexpr (std::is_same_v<T, bool>)
+			{
+				GUIDrawer::DrawBoolean(*m_shaderSettingsColumns, formattedType, arg);
+			}
+			else if constexpr (std::is_same_v<T, int>)
+			{
+				GUIDrawer::DrawScalar<int>(*m_shaderSettingsColumns, formattedType, arg);
+			}
+			else if constexpr (std::is_same_v<T, float>)
+			{
+				GUIDrawer::DrawScalar<float>(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector2>)
+			{
+				GUIDrawer::DrawVec2(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector3>)
+			{
+				DrawHybridVec3(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector4>)
+			{
+				DrawHybridVec4(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, Texture*>)
+			{
+				GUIDrawer::DrawTexture(*m_shaderSettingsColumns, formattedType, arg);
+			}
+			// No UI for TextureHandle* since it's not handled in the original code
+		};
 
-			// Apply the visitor to the variant
-			std::visit(drawVisitor, *info.second);
-		}
+		// Apply the visitor to the variant
+		std::visit(drawVisitor, prop);
 	}
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -429,7 +429,6 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialFeaturesContent()
 		auto& features = shader->GetFeatures();
 		for (const auto& feature : features)
 		{
-			// bool enabled = m_target->HasFeature(feature);
 			GUIDrawer::DrawBoolean(
 				*m_featureSettingsColumns,
 				feature,

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -253,6 +253,12 @@ namespace OvRendering::Data
 		*/
 		bool HasFeature(const std::string& p_feature) const;
 
+		/**
+		* Returns true if the material supports a feature
+		* @param p_feature
+		*/
+		bool SupportsFeature(const std::string& p_feature) const;
+
 	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -68,8 +68,12 @@ namespace OvRendering::Data
 		/**
 		* Bind the material and send its uniform data to the GPU
 		* @param p_emptyTexture (The texture to use if a texture uniform is null)
+		* @param p_featureSetOverride
 		*/
-		void Bind(OvRendering::HAL::Texture* p_emptyTexture = nullptr);
+		void Bind(
+			HAL::Texture* p_emptyTexture = nullptr,
+			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_featureSetOverride = std::nullopt
+		);
 
 		/**
 		* Unbind the material

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -226,9 +226,33 @@ namespace OvRendering::Data
 		*/
 		PropertyMap& GetProperties();
 
+		/**
+		* Returns the feature set of this material
+		*/
+		Resources::Shader::FeatureSet& GetFeatures();
+
+		/**
+		* Adds a feature to the material
+		* @param p_feature
+		*/
+		void AddFeature(const std::string& p_feature);
+
+		/**
+		* Removes a feature from the material
+		* @param p_feature
+		*/
+		void RemoveFeature(const std::string& p_feature);
+
+		/**
+		* Returns true if the material has a feature
+		* @param p_feature
+		*/
+		bool HasFeature(const std::string& p_feature) const;
+
 	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
+		Resources::Shader::FeatureSet m_features;
 
 		bool m_userInterface = false;
 		bool m_blendable = false;

--- a/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
@@ -22,7 +22,8 @@ namespace OvRendering::Entities
 	{
 		OvTools::Utils::OptRef<OvRendering::Resources::IMesh> mesh;
 		OvTools::Utils::OptRef<OvRendering::Data::Material> material;
-		OvRendering::Data::StateMask stateMask;
-		OvRendering::Settings::EPrimitiveMode primitiveMode = OvRendering::Settings::EPrimitiveMode::TRIANGLES;
+		Data::StateMask stateMask;
+		Settings::EPrimitiveMode primitiveMode = OvRendering::Settings::EPrimitiveMode::TRIANGLES;
+		std::optional<Resources::Shader::FeatureSet> featureSetOverride = std::nullopt;
 	};
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
@@ -56,6 +56,11 @@ namespace OvRendering::Resources
 		*/
 		const FeatureSet& GetFeatures() const;
 
+		/**
+		* Return all programs
+		*/
+		const ProgramVariants& GetPrograms() const;
+
 	private:
 		Shader(
 			const std::string p_path,

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -215,7 +215,13 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 			}
 		}
 
-		material->Bind(&m_emptyTexture->GetTexture());
+		material->Bind(
+			&m_emptyTexture->GetTexture(),
+			p_drawable.featureSetOverride.has_value() ?
+			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet>(p_drawable.featureSetOverride.value()) :
+			std::nullopt
+		);
+
 		m_driver.Draw(p_pso, mesh.value(), p_drawable.primitiveMode, gpuInstances);
 		material->Unbind();
 	}

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -4,6 +4,9 @@
 * @licence: MIT
 */
 
+#include <format>
+#include <ranges>
+
 #include <tracy/Tracy.hpp>
 
 #include <OvDebug/Assertion.h>
@@ -81,12 +84,15 @@ void OvRendering::Data::Material::FillUniform()
 {
 	m_properties.clear();
 
-	for (const auto& uniform : m_shader->GetProgram().GetUniforms())
+	for (const auto& program : m_shader->GetPrograms() | std::views::values)
 	{
-		m_properties.emplace(uniform.name, MaterialProperty{
-			.value = UniformToPropertyValue(uniform.defaultValue),
-			.singleUse = false
-		});
+		for (const auto& uniform : program->GetUniforms())
+		{
+			m_properties.emplace(uniform.name, MaterialProperty{
+				.value = UniformToPropertyValue(uniform.defaultValue),
+				.singleUse = false
+			});
+		}
 	}
 }
 

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -90,7 +90,10 @@ void OvRendering::Data::Material::FillUniform()
 	}
 }
 
-void OvRendering::Data::Material::Bind(OvRendering::HAL::Texture* p_emptyTexture)
+void OvRendering::Data::Material::Bind(
+	OvRendering::HAL::Texture* p_emptyTexture,
+	OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_featureSetOverride
+)
 {
 	ZoneScoped;
 
@@ -99,7 +102,10 @@ void OvRendering::Data::Material::Bind(OvRendering::HAL::Texture* p_emptyTexture
 
 	OVASSERT(IsValid(), "Attempting to bind an invalid material.");
 
-	auto& program = m_shader->GetProgram(m_features);
+	auto& program = m_shader->GetProgram(
+		p_featureSetOverride.value_or(m_features)
+	);
+
 	program.Bind();
 
 	int textureSlot = 0;

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -99,7 +99,7 @@ void OvRendering::Data::Material::Bind(OvRendering::HAL::Texture* p_emptyTexture
 
 	OVASSERT(IsValid(), "Attempting to bind an invalid material.");
 
-	auto& program = m_shader->GetProgram();
+	auto& program = m_shader->GetProgram(m_features);
 	program.Bind();
 
 	int textureSlot = 0;
@@ -364,4 +364,24 @@ const OvRendering::Data::StateMask OvRendering::Data::Material::GenerateStateMas
 OvRendering::Data::Material::PropertyMap& OvRendering::Data::Material::GetProperties()
 {
 	return m_properties;
+}
+
+OvRendering::Resources::Shader::FeatureSet& OvRendering::Data::Material::GetFeatures()
+{
+	return m_features;
+}
+
+void OvRendering::Data::Material::AddFeature(const std::string& p_feature)
+{
+	m_features.insert(p_feature);
+}
+
+void OvRendering::Data::Material::RemoveFeature(const std::string& p_feature)
+{
+	m_features.erase(p_feature);
+}
+
+bool OvRendering::Data::Material::HasFeature(const std::string& p_feature) const
+{
+	return m_features.contains(p_feature);
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -397,3 +397,8 @@ bool OvRendering::Data::Material::HasFeature(const std::string& p_feature) const
 {
 	return m_features.contains(p_feature);
 }
+
+bool OvRendering::Data::Material::SupportsFeature(const std::string& p_feature) const
+{
+	return m_shader->GetFeatures().contains(p_feature);
+}

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -73,3 +73,8 @@ void OvRendering::Resources::Shader::SetPrograms(ProgramVariants&& p_programs)
 		m_features.insert(key.begin(), key.end());
 	}
 }
+
+const OvRendering::Resources::Shader::ProgramVariants& OvRendering::Resources::Shader::GetPrograms() const
+{
+	return m_programs;
+}


### PR DESCRIPTION
## Description
- Updated material to store a "current feature set"
- Exposed the current feature set through the material editor
- Updated material binding to use the program matching the current feature set
- Added serialization/deserialization of feature set
- Added an option to override the feature set of a material (for render passes to enforce some features, i.e. depth only, debug...)
- Updated material editor to show all uniforms, even the ones that are feature-specific

_Follow-up work: we should update the material editor so that widgets for shader uniforms and features are updated after a shader has been recompiled. Right now, only unselecting/reselecting the material, or changing the shader will trigger uniforms/features to be updated to reflect the last compilation result._

## Review Guidance
_N/A_

## To-Do
- [x] Make sure that if some uniforms are inside a `#ifdef` block, they are still displayed in the editor
- [x] Handle case when the same uniform name is used by 2 variants for different types/purposes

## Screenshots

https://github.com/user-attachments/assets/2cd860a2-b382-4367-9b61-8c10de271db0


