### PR TITLE
Remove OpenGL context version selection setting (#469)

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -180,8 +180,6 @@ void OvEditor::Core::Context::ResetProjectSettings()
 	projectSettings.Add<bool>("vsync", true);
 	projectSettings.Add<bool>("multisampling", true);
 	projectSettings.Add<int>("samples", 4);
-	projectSettings.Add<int>("opengl_major", 4);
-	projectSettings.Add<int>("opengl_minor", 5);
 	projectSettings.Add<bool>("dev_build", true);
 }
 
@@ -197,8 +195,6 @@ bool OvEditor::Core::Context::IsProjectSettingsIntegrityVerified()
 		projectSettings.IsKeyExisting("vsync") &&
 		projectSettings.IsKeyExisting("multisampling") &&
 		projectSettings.IsKeyExisting("samples") &&
-		projectSettings.IsKeyExisting("opengl_major") &&
-		projectSettings.IsKeyExisting("opengl_minor") &&
 		projectSettings.IsKeyExisting("dev_build");
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
@@ -80,8 +80,6 @@ OvEditor::Panels::ProjectSettings::ProjectSettings(const std::string & p_title, 
 		GUIDrawer::DrawBoolean(columns, "Vertical Sync.", GenerateGatherer<bool>("vsync"), GenerateProvider<bool>("vsync"));
 		GUIDrawer::DrawBoolean(columns, "Multi-sampling", GenerateGatherer<bool>("multisampling"), GenerateProvider<bool>("multisampling"));
 		GUIDrawer::DrawScalar<int>(columns, "Samples", GenerateGatherer<int>("samples"), GenerateProvider<int>("samples"), 1, 2, 16);
-		GUIDrawer::DrawScalar<int>(columns, "OpenGL Major", GenerateGatherer<int>("opengl_major"), GenerateProvider<int>("opengl_major"), 1, 3, 4);
-		GUIDrawer::DrawScalar<int>(columns, "OpenGL Minor", GenerateGatherer<int>("opengl_minor"), GenerateProvider<int>("opengl_minor"), 1, 0, 6);
 	}
 
 	{

--- a/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/Overload/OvGame/src/OvGame/Core/Context.cpp
@@ -61,8 +61,6 @@ OvGame::Core::Context::Context() :
 
 	/* Settings */
 	OvWindowing::Settings::DeviceSettings deviceSettings;
-	projectSettings.TryGet("opengl_major", deviceSettings.contextMajorVersion);
-	projectSettings.TryGet("opengl_minor", deviceSettings.contextMinorVersion);
 	projectSettings.TryGet("samples", deviceSettings.samples);
 
 	OvWindowing::Settings::WindowSettings windowSettings;


### PR DESCRIPTION
**Remove OpenGL Version Settings from Project Settings**

This PR removes the OpenGL Major and Minor version settings from the Project Settings window as described in issue #469 

**Description:**

*   Took out the "OpenGL Major" and "OpenGL Minor" fields from the Rendering section in Project Settings (`OvEditor/Panels/ProjectSettings.cpp`).
*   Removed the related settings (`context_major_version`, `context_minor_version`) from the code that creates default project files and checks them (`OvEditor/Core/Context.cpp`).
*   Stopped the game from trying to read these settings when it starts up (`OvGame/Core/Context.cpp`), as the defaults are already correct (4.5).

**Screenshots:**

Project Settings window with removed version settings:


![removed versions](https://github.com/user-attachments/assets/6fc3c753-db07-48f5-a2e3-cc75cc08eb57)

**Related Issue:**
#469