### PR TITLE
Sanitized premake settings and removed unnecessary includes

### DIFF
--- a/Dependencies/ImGui/premake5.lua
+++ b/Dependencies/ImGui/premake5.lua
@@ -2,11 +2,23 @@ project "ImGui"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.cpp", "**.lua" }
-	includedirs { "include", dependdir .. "glfw/include", dependdir .. "glad/include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+	warnings "Off"
+
+	files {
+		"**.h",
+		"**.cpp",
+		"**.lua"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "glfw/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/assimp/premake5.lua
+++ b/Dependencies/assimp/premake5.lua
@@ -17,12 +17,11 @@
 
 project 'assimp'
 	kind 'StaticLib'
-	warnings 'Off'
 	language "C++"
 	cppdialect "C++20"
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+	warnings "Off"
 
 	includedirs {
 		'./',
@@ -58,6 +57,7 @@ project 'assimp'
 		'code/AssetLib/Obj/**',
 		'code/AssetLib/FBX/**',
 	}
+
 	-- Importers
 	defines {
 		'ASSIMP_BUILD_NO_3D_IMPORTER',
@@ -112,6 +112,7 @@ project 'assimp'
 		'ASSIMP_BUILD_NO_X3D_IMPORTER',
 		'ASSIMP_BUILD_NO_XGL_IMPORTER'
 	}
+
 	-- Exporters
 	defines {
 		'ASSIMP_BUILD_NO_COLLADA_EXPORTER',

--- a/Dependencies/bullet3/premake5.lua
+++ b/Dependencies/bullet3/premake5.lua
@@ -1,5 +1,7 @@
 project "bullet3"
 	kind "SharedItems"
-	files { "**.h", "**.lua" }
-	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.lua"
+	}

--- a/Dependencies/glad/premake5.lua
+++ b/Dependencies/glad/premake5.lua
@@ -2,11 +2,19 @@ project "glad"
 	kind "StaticLib"
 	language "C"
 	cdialect "C17"
-	files { "**.h", "**.c", "**.lua" }
-	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+	warnings "Off"
+
+	files {
+		"**.h",
+		"**.c",
+		"**.lua"
+	}
+
+	includedirs {
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/glfw/premake5.lua
+++ b/Dependencies/glfw/premake5.lua
@@ -2,12 +2,24 @@ project "glfw"
 	kind "StaticLib"
 	language "C"
 	cdialect "C17"
-	files { "**.h", "**.c", "**.m", "**.lua" }
-	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	defines { "_GLFW_WIN32" }
+	warnings "Off"
+
+	files {
+		"**.h",
+		"**.c",
+		"**.m",
+		"**.lua"
+	}
+
+	includedirs {
+		"include"
+	}
+
+	defines {
+		"_GLFW_WIN32"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/lua/premake5.lua
+++ b/Dependencies/lua/premake5.lua
@@ -6,7 +6,6 @@ project "lua"
 	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/sol/premake5.lua
+++ b/Dependencies/sol/premake5.lua
@@ -1,5 +1,8 @@
 project "sol"
 	kind "SharedItems"
-	files { "**.h", "**.hpp", "**.lua" }
-	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.hpp",
+		"**.lua"
+	}

--- a/Dependencies/soloud/premake5.lua
+++ b/Dependencies/soloud/premake5.lua
@@ -2,12 +2,24 @@ project "soloud"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.cpp", "**.c", "**.lua" }
-	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	defines {"WITH_MINIAUDIO"}
+	warnings "Off"
+
+	files {
+		"**.h",
+		"**.cpp",
+		"**.c",
+		"**.lua"
+	}
+
+	includedirs {
+		"include"
+	}
+
+	defines {
+		"WITH_MINIAUDIO"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/stb_image/premake5.lua
+++ b/Dependencies/stb_image/premake5.lua
@@ -1,5 +1,7 @@
 project "stb_image"
 	kind "SharedItems"
-	files { "**.h", "**.lua" }
-	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.lua"
+	}

--- a/Dependencies/tinyxml2/premake5.lua
+++ b/Dependencies/tinyxml2/premake5.lua
@@ -2,11 +2,19 @@ project "tinyxml2"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.cpp", "**.lua" }
-	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+	warnings "Off"
+
+	files {
+		"**.h",
+		"**.cpp",
+		"**.lua"
+	}
+
+	includedirs {
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Dependencies/tracy/premake5.lua
+++ b/Dependencies/tracy/premake5.lua
@@ -2,13 +2,17 @@ project "tracy"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.hpp", "**.cpp", "**.lua" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	defines { "_CRT_SECURE_NO_WARNINGS" }
-	disablewarnings { "4996" } -- Ignore deprecated functions warnings
+	warnings "Off"
 	linkoptions { "/ignore:4006" } -- Ignore "symbol already defined" warnings
+
+	files {
+		"**.h",
+		"**.hpp",
+		"**.cpp",
+		"**.lua"
+	}
 	
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvAudio/premake5.lua
+++ b/Sources/Overload/OvAudio/premake5.lua
@@ -2,15 +2,29 @@ project "OvAudio"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		dependdir .. "soloud/include",
-		"%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "soloud/include",
+
+		-- Overload SDK
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvCore/include/OvCore/Helpers/Serializer.h
+++ b/Sources/Overload/OvCore/include/OvCore/Helpers/Serializer.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <string>
-#include <tinyxml2.h>
 
 #include <OvMaths/FVector2.h>
 #include <OvMaths/FVector3.h>
@@ -32,6 +31,12 @@ namespace OvAudio::Resources
 namespace OvCore::Resources
 {
 	class Material;
+}
+
+namespace tinyxml2
+{
+	class XMLDocument;
+	class XMLNode;
 }
 
 namespace OvCore::Helpers

--- a/Sources/Overload/OvCore/include/OvCore/Scripting/Lua/LuaScript.h
+++ b/Sources/Overload/OvCore/include/OvCore/Scripting/Lua/LuaScript.h
@@ -10,11 +10,22 @@
 
 #include <OvCore/Scripting/Common/TScript.h>
 
-#include <sol/sol.hpp>
-
 namespace OvCore::ECS
 {
 	class Actor;
+}
+
+namespace sol
+{
+	template <bool b>
+	class basic_reference;
+	using reference = basic_reference<false>;
+
+	template <bool, typename>
+	class basic_table_core;
+	template <bool b>
+	using table_core = basic_table_core<b, reference>;
+	using table = table_core<false>;
 }
 
 namespace OvCore::Scripting
@@ -24,7 +35,7 @@ namespace OvCore::Scripting
 	*/
 	struct LuaScriptContext
 	{
-		sol::table table;
+		std::unique_ptr<sol::table> table;
 	};
 
 	using LuaScriptBase = TScript<EScriptingLanguage::LUA, LuaScriptContext>;

--- a/Sources/Overload/OvCore/include/OvCore/Scripting/Lua/LuaScriptEngine.h
+++ b/Sources/Overload/OvCore/include/OvCore/Scripting/Lua/LuaScriptEngine.h
@@ -11,11 +11,14 @@
 
 #include <OvCore/Scripting/Common/TScriptEngine.h>
 
-#include <sol/sol.hpp>
-
 namespace OvCore::ECS::Components
 {
 	class Behaviour;
+}
+
+namespace sol
+{
+	class state;
 }
 
 namespace OvCore::Scripting
@@ -47,7 +50,7 @@ namespace OvCore::Scripting
 		/**
 		* Destructor of the Lua script engine
 		*/
-		~LuaScriptEngine();
+		virtual ~LuaScriptEngine();
 
 		/**
 		* Create the Lua state

--- a/Sources/Overload/OvCore/premake5.lua
+++ b/Sources/Overload/OvCore/premake5.lua
@@ -2,19 +2,42 @@ project "OvCore"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs { 
-		dependdir .. "glfw/include", dependdir .. "stb_image/include", dependdir .. "lua/include", dependdir .. "sol/include", dependdir .. "bullet3/include", dependdir .. "glad/include", dependdir .. "soloud/include", dependdir .. "ImGui/include", dependdir .. "tinyxml2/include", dependdir .. "tracy",
-		"%{wks.location}/OvAnalytics/include", "%{wks.location}/OvAudio/include", "%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvPhysics/include",
-		"%{wks.location}/OvRendering/include", "%{wks.location}/OvTools/include", "%{wks.location}/OvUI/include", "%{wks.location}/OvWindowing/include",
-		"include"
-	}
-
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	
 	buildoptions { "/bigobj" }
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "bullet3/include",
+		dependdir .. "glad/include",
+		dependdir .. "ImGui/include",
+		dependdir .. "lua/include",
+		dependdir .. "sol/include",
+		dependdir .. "tinyxml2/include",
+		dependdir .. "tracy",
+
+		-- Overload SDK
+		"%{wks.location}/OvAudio/include",
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvPhysics/include",
+		"%{wks.location}/OvRendering/include",
+		"%{wks.location}/OvTools/include",
+		"%{wks.location}/OvUI/include",
+		"%{wks.location}/OvWindowing/include",
+
+		-- Current project
+		"include",
+	}
+	
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvCore/premake5.lua
+++ b/Sources/Overload/OvCore/premake5.lua
@@ -16,7 +16,6 @@ project "OvCore"
 
 	includedirs {
 		-- Dependencies
-		dependdir .. "bullet3/include",
 		dependdir .. "glad/include",
 		dependdir .. "ImGui/include",
 		dependdir .. "lua/include",

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Actor.cpp
@@ -6,22 +6,23 @@
 
 #include <algorithm>
 
-#include "OvCore/ECS/Actor.h"
+#include <tinyxml2.h>
 
-#include "OvCore/ECS/Components/CPhysicalBox.h"
-#include "OvCore/ECS/Components/CPhysicalSphere.h"
-#include "OvCore/ECS/Components/CPhysicalCapsule.h"
-#include "OvCore/ECS/Components/CCamera.h"
-#include "OvCore/ECS/Components/CModelRenderer.h"
-#include "OvCore/ECS/Components/CMaterialRenderer.h"
-#include "OvCore/ECS/Components/CAudioSource.h"
-#include "OvCore/ECS/Components/CAudioListener.h"
-#include "OvCore/ECS/Components/CPointLight.h"
-#include "OvCore/ECS/Components/CDirectionalLight.h"
-#include "OvCore/ECS/Components/CSpotLight.h"
-#include "OvCore/ECS/Components/CAmbientBoxLight.h"
-#include "OvCore/ECS/Components/CAmbientSphereLight.h"
-#include "OvCore/ECS/Components/CPostProcessStack.h"
+#include <OvCore/ECS/Actor.h>
+#include <OvCore/ECS/Components/CAmbientBoxLight.h>
+#include <OvCore/ECS/Components/CAmbientSphereLight.h>
+#include <OvCore/ECS/Components/CAudioListener.h>
+#include <OvCore/ECS/Components/CAudioSource.h>
+#include <OvCore/ECS/Components/CCamera.h>
+#include <OvCore/ECS/Components/CDirectionalLight.h>
+#include <OvCore/ECS/Components/CMaterialRenderer.h>
+#include <OvCore/ECS/Components/CModelRenderer.h>
+#include <OvCore/ECS/Components/CPhysicalBox.h>
+#include <OvCore/ECS/Components/CPhysicalCapsule.h>
+#include <OvCore/ECS/Components/CPhysicalSphere.h>
+#include <OvCore/ECS/Components/CPointLight.h>
+#include <OvCore/ECS/Components/CPostProcessStack.h>
+#include <OvCore/ECS/Components/CSpotLight.h>
 
 OvTools::Eventing::Event<OvCore::ECS::Actor&> OvCore::ECS::Actor::DestroyedEvent;
 OvTools::Eventing::Event<OvCore::ECS::Actor&> OvCore::ECS::Actor::CreatedEvent;

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CCamera.cpp
@@ -4,12 +4,14 @@
 * @licence: MIT
 */
 
+#include <tinyxml2.h>
+
+#include <OvCore/ECS/Actor.h>
+#include <OvCore/ECS/Components/CCamera.h>
+
+#include <OvUI/Plugins/DataDispatcher.h>
 #include <OvUI/Widgets/Drags/DragFloat.h>
 #include <OvUI/Widgets/Selection/ComboBox.h>
-#include <OvUI/Plugins/DataDispatcher.h>
-
-#include "OvCore/ECS/Components/CCamera.h"
-#include "OvCore/ECS/Actor.h"
 
 OvCore::ECS::Components::CCamera::CCamera(ECS::Actor& p_owner)
 	: AComponent(p_owner), m_camera{ p_owner.transform.GetFTransform() }

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -4,20 +4,22 @@
 * @licence: MIT
 */
 
-#include <OvUI/Widgets/InputFields/InputInt.h>
-#include <OvUI/Widgets/Layout/Group.h>
-#include <OvUI/Widgets/Buttons/Button.h>
-#include <OvUI/Widgets/Buttons/ButtonSmall.h>
-#include <OvUI/Widgets/Texts/TextColored.h>
-#include <OvUI/Plugins/DDTarget.h>
+#include <tinyxml2.h>
+
+#include <OvCore/ECS/Actor.h>
+#include <OvCore/ECS/Components/CMaterialRenderer.h>
+#include <OvCore/ECS/Components/CModelRenderer.h>
+#include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/ResourceManagement/MaterialManager.h>
 
 #include <OvTools/Utils/PathParser.h>
 
-#include "OvCore/ECS/Actor.h"
-#include "OvCore/ECS/Components/CMaterialRenderer.h"
-#include "OvCore/ECS/Components/CModelRenderer.h"
-#include "OvCore/ResourceManagement/MaterialManager.h"
-#include "OvCore/Global/ServiceLocator.h"
+#include <OvUI/Widgets/Buttons/Button.h>
+#include <OvUI/Widgets/Buttons/ButtonSmall.h>
+#include <OvUI/Plugins/DDTarget.h>
+#include <OvUI/Widgets/InputFields/InputInt.h>
+#include <OvUI/Widgets/Layout/Group.h>
+#include <OvUI/Widgets/Texts/TextColored.h>
 
 OvCore::ECS::Components::CMaterialRenderer::CMaterialRenderer(ECS::Actor & p_owner) : AComponent(p_owner)
 {

--- a/Sources/Overload/OvCore/src/OvCore/Helpers/Serializer.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Helpers/Serializer.cpp
@@ -4,13 +4,15 @@
 * @licence: MIT
 */
 
-#include "OvCore/ResourceManagement/TextureManager.h"
-#include "OvCore/ResourceManagement/ModelManager.h"
-#include "OvCore/ResourceManagement/ShaderManager.h"
-#include "OvCore/ResourceManagement/MaterialManager.h"
-#include "OvCore/ResourceManagement/SoundManager.h"
-#include "OvCore/Global/ServiceLocator.h"
-#include "OvCore/Helpers/Serializer.h"
+#include <tinyxml2.h>
+
+#include <OvCore/ResourceManagement/TextureManager.h>
+#include <OvCore/ResourceManagement/ModelManager.h>
+#include <OvCore/ResourceManagement/ShaderManager.h>
+#include <OvCore/ResourceManagement/MaterialManager.h>
+#include <OvCore/ResourceManagement/SoundManager.h>
+#include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/Helpers/Serializer.h>
 
 void OvCore::Helpers::Serializer::SerializeBoolean(tinyxml2::XMLDocument & p_doc, tinyxml2::XMLNode * p_node, const std::string & p_name, bool p_value)
 {

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Loaders/MaterialLoader.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Loaders/MaterialLoader.cpp
@@ -4,8 +4,9 @@
 * @licence: MIT
 */
 
-#include <OvCore/Resources/Loaders/MaterialLoader.h>
+#include <tinyxml2.h>
 
+#include <OvCore/Resources/Loaders/MaterialLoader.h>
 #include <OvDebug/Logger.h>
 
 OvCore::Resources::Material * OvCore::Resources::Loaders::MaterialLoader::Create(const std::string & p_path)

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <tinyxml2.h>
+
 #include <OvCore/Resources/Material.h>
 
 void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tinyxml2::XMLNode* p_node)

--- a/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <string>
 
+#include <tinyxml2.h>
 #include <tracy/Tracy.hpp>
 
 #include <OvCore/ECS/Components/CAmbientSphereLight.h>

--- a/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaActorBindings.cpp
@@ -71,7 +71,7 @@ void BindLuaActor(sol::state& p_luaState)
 			{
 				if (auto script = behaviour->GetScript())
 				{
-					return static_cast<OvCore::Scripting::LuaScript&>(script.value()).GetContext().table;
+					return *static_cast<OvCore::Scripting::LuaScript&>(script.value()).GetContext().table;
 				}
 			}
 			return sol::nil;

--- a/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/LuaScript.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <sol/sol.hpp>
+
 #include <OvDebug/Logger.h>
 #include <OvDebug/Assertion.h>
 
@@ -19,15 +21,15 @@ OvCore::Scripting::LuaScriptBase::~TScript() = default;
 template<>
 bool OvCore::Scripting::LuaScriptBase::IsValid() const
 {
-	return m_context.table.valid();
+	return m_context.table && m_context.table->valid();
 }
 
 OvCore::Scripting::LuaScript::LuaScript(sol::table table)
 {
-	m_context.table = table;
+	m_context.table = std::make_unique<sol::table>(table);
 }
 
 void OvCore::Scripting::LuaScript::SetOwner(OvCore::ECS::Actor& p_owner)
 {
-	m_context.table["owner"] = &p_owner;
+	(*m_context.table)["owner"] = &p_owner;
 }

--- a/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <sol/sol.hpp>
+
 #include <tracy/Tracy.hpp>
 
 #include <OvDebug/Logger.h>
@@ -34,7 +36,7 @@ void ExecuteLuaFunction(OvCore::ECS::Components::Behaviour& p_behaviour, const s
 	OVASSERT(context.has_value(), "The given context is null");
 	OVASSERT(context->IsValid(), "The given context is invalid");
 
-	const sol::table& table = static_cast<OvCore::Scripting::LuaScript&>(context.value()).GetContext().table;
+	const sol::table& table = *static_cast<OvCore::Scripting::LuaScript&>(context.value()).GetContext().table;
 
 	if (table[p_functionName].valid())
 	{

--- a/Sources/Overload/OvDebug/premake5.lua
+++ b/Sources/Overload/OvDebug/premake5.lua
@@ -2,14 +2,24 @@ project "OvDebug"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		"%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Overload SDK
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -6,19 +6,22 @@
 
 #pragma once
 
-#include <tinyxml2.h>
-
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvEditor/Core/Context.h>
 #include <OvEditor/Core/PanelsManager.h>
 #include <OvTools/Filesystem/IniFile.h>
 #include <OvTools/Utils/PathParser.h>
 
-#define EDITOR_EXEC(action)					OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().action
-#define EDITOR_BIND(method, ...)			std::bind(&OvEditor::Core::EditorActions::method, &OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>(), ##__VA_ARGS__)
-#define EDITOR_EVENT(target)				OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().target
-#define EDITOR_CONTEXT(instance)			OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().GetContext().instance
-#define EDITOR_PANEL(type, id)				OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().GetPanelsManager().GetPanelAs<type>(id)
+#define EDITOR_EXEC(action) OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().action
+#define EDITOR_BIND(method, ...) std::bind(&OvEditor::Core::EditorActions::method, &OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>(), ##__VA_ARGS__)
+#define EDITOR_EVENT(target) OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().target
+#define EDITOR_CONTEXT(instance) OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().GetContext().instance
+#define EDITOR_PANEL(type, id) OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().GetPanelsManager().GetPanelAs<type>(id)
+
+namespace tinyxml2
+{
+	class XMLDocument;
+}
 
 namespace OvEditor::Core
 {
@@ -34,6 +37,11 @@ namespace OvEditor::Core
 		* @param p_panelsManager
 		*/
 		EditorActions(Context& p_context, PanelsManager& p_panelsManager);
+
+		/**
+		* Destructor
+		*/
+		virtual ~EditorActions();
 
 		#pragma region TOOLS
 		/**
@@ -159,7 +167,7 @@ namespace OvEditor::Core
 		* Create an empty actor
 		* @param p_focusOnCreation
 		* @param p_parent
-        * @param p_name
+		* @param p_name
 		*/
 		OvCore::ECS::Actor&	CreateEmptyActor(bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr, const std::string& p_name = "");
 
@@ -169,7 +177,7 @@ namespace OvEditor::Core
 		* @param p_path
 		* @param p_focusOnCreation
 		* @param p_parent
-        * @param p_name
+		* @param p_name
 		*/
 		OvCore::ECS::Actor&	CreateActorWithModel(const std::string& p_path, bool p_focusOnCreation = true, OvCore::ECS::Actor* p_parent = nullptr, const std::string& p_name = "");
 
@@ -210,12 +218,12 @@ namespace OvEditor::Core
 		* Returns the selected actor. Make sur you verified that an actor is selected
 		* with IsAnyActorSelected() before calling this method
 		*/
-		OvCore::ECS::Actor&		GetSelectedActor() const;
+		OvCore::ECS::Actor& GetSelectedActor() const;
 
 		/**
 		* Moves the camera to the target actor
 		*/
-		void					MoveToTarget(OvCore::ECS::Actor& p_target);
+		void MoveToTarget(OvCore::ECS::Actor& p_target);
 		#pragma endregion
 
 		#pragma region RESOURCE_MANAGEMENT
@@ -397,8 +405,8 @@ namespace OvEditor::Core
 
 		std::vector<std::pair<uint32_t, std::function<void()>>> m_delayedActions;
 
-		tinyxml2::XMLDocument m_sceneBackup;
+		std::unique_ptr<tinyxml2::XMLDocument> m_sceneBackup;
 	};
 }
 
-#include "OvEditor/Core/EditorActions.inl"
+#include <OvEditor/Core/EditorActions.inl>

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <tinyxml2.h>
+
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvTools/Filesystem/IniFile.h>
 #include <OvTools/Utils/PathParser.h>

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -9,11 +9,10 @@
 #include <tinyxml2.h>
 
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvEditor/Core/Context.h>
+#include <OvEditor/Core/PanelsManager.h>
 #include <OvTools/Filesystem/IniFile.h>
 #include <OvTools/Utils/PathParser.h>
-
-#include "OvEditor/Core/Context.h"
-#include "OvEditor/Core/PanelsManager.h"
 
 #define EDITOR_EXEC(action)					OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>().action
 #define EDITOR_BIND(method, ...)			std::bind(&OvEditor::Core::EditorActions::method, &OvCore::Global::ServiceLocator::Get<OvEditor::Core::EditorActions>(), ##__VA_ARGS__)

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.inl
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.inl
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "OvEditor/Core/EditorActions.h"
+#include <OvEditor/Core/EditorActions.h>
 
 namespace OvEditor::Core
 {
@@ -17,7 +17,7 @@ namespace OvEditor::Core
 
 		T& component = instance.AddComponent<T>();
 
-        instance.SetName(component.GetName());
+		instance.SetName(component.GetName());
 
 		if (p_focusOnCreation)
 			SelectActor(instance);

--- a/Sources/Overload/OvEditor/premake5.lua
+++ b/Sources/Overload/OvEditor/premake5.lua
@@ -1,26 +1,83 @@
 project "OvEditor"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl","**.cpp", "**.lua", "**.rc", "**.ini" }
+	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
+	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
+	debugdir "%{wks.location}/../../Build/%{cfg.buildcfg}"
+	
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini",
+		"**.rc",
+	}
+
 	includedirs {
-		dependdir .. "glfw/include", dependdir .. "stb_image/include", dependdir .. "lua/include", dependdir .. "sol/include", dependdir .. "bullet3/include", dependdir .. "glad/include", dependdir .. "soloud/include", dependdir .. "ImGui/include", dependdir .. "tinyxml2/include", dependdir .. "tracy",
-		"%{wks.location}/OvAnalytics/include", "%{wks.location}/OvAudio/include", "%{wks.location}/OvCore/include",
-		"%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvPhysics/include",
-		"%{wks.location}/OvRendering/include", "%{wks.location}/OvTools/include", "%{wks.location}/OvUI/include", "%{wks.location}/OvWindowing/include",
+		-- Dependencies
+		dependdir .. "bullet3/include",
+		dependdir .. "glad/include",
+		dependdir .. "ImGui/include",
+		dependdir .. "lua/include",
+		dependdir .. "sol/include",
+		dependdir .. "tinyxml2/include",
+		dependdir .. "tracy",
+
+		-- Overload SDK
+		"%{wks.location}/OvAudio/include",
+		"%{wks.location}/OvCore/include",
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvPhysics/include",
+		"%{wks.location}/OvRendering/include",
+		"%{wks.location}/OvTools/include",
+		"%{wks.location}/OvUI/include",
+		"%{wks.location}/OvWindowing/include",
+
+		-- Current project
 		"include"
 	}
 
-	libdirs { dependdir .. "bullet3/lib/%{cfg.buildcfg}", dependdir .. "lua/lib" }
-	links {
-		"Bullet3Collision.lib", "Bullet3Common.lib", "Bullet3Dynamics.lib", "Bullet3Geometry.lib", "BulletCollision.lib", "BulletDynamics.lib", "BulletSoftBody.lib", "LinearMath.lib", "opengl32.lib", "dbghelp.lib",
-		"ImGui", "tinyxml2", "lua", "glad", "glfw", "assimp", "tracy", "soloud",
-		"OvAudio", "OvCore", "OvDebug", "OvMaths", "OvPhysics", "OvRendering", "OvTools", "OvUI", "OvWindowing"
-    }
+	libdirs {
+		dependdir .. "bullet3/lib/%{cfg.buildcfg}",
+		dependdir .. "lua/lib"
+	}
 
-	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
-	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	debugdir "%{wks.location}/../../Build/%{cfg.buildcfg}"
+	links {
+		-- Precompiled Libraries
+		"dbghelp.lib",
+		"opengl32.lib",
+		"Bullet3Collision.lib",
+		"Bullet3Common.lib",
+		"Bullet3Dynamics.lib",
+		"Bullet3Geometry.lib",
+		"BulletCollision.lib",
+		"BulletDynamics.lib",
+		"BulletSoftBody.lib",
+		"LinearMath.lib",
+
+		-- Dependencies
+		"assimp",
+		"glad",
+		"glfw",
+		"ImGui",
+		"lua",
+		"soloud",
+		"tinyxml2",
+		"tracy",
+
+		-- Overload SDK
+		"OvAudio",
+		"OvCore",
+		"OvDebug",
+		"OvMaths",
+		"OvPhysics",
+		"OvRendering",
+		"OvTools",
+		"OvUI",
+		"OvWindowing"
+    }
 
 	postbuildcommands {
 		"for /f \"delims=|\" %%i in ('dir /B /S \"%{dependdir}\\*.dll\"') do xcopy /Q /Y \"%%i\" \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\"",
@@ -56,5 +113,6 @@ project "OvEditor"
 		kind "WindowedApp"
 
 	filter { "system:windows" }
+		characterset ("MBCS")
 		-- forces post-build commands to trigger even if nothing changed
 		fastuptodate "Off"

--- a/Sources/Overload/OvEditor/premake5.lua
+++ b/Sources/Overload/OvEditor/premake5.lua
@@ -18,8 +18,6 @@ project "OvEditor"
 		-- Dependencies
 		dependdir .. "glad/include",
 		dependdir .. "ImGui/include",
-		dependdir .. "lua/include",
-		dependdir .. "sol/include",
 		dependdir .. "tinyxml2/include",
 		dependdir .. "tracy",
 

--- a/Sources/Overload/OvEditor/premake5.lua
+++ b/Sources/Overload/OvEditor/premake5.lua
@@ -16,7 +16,6 @@ project "OvEditor"
 
 	includedirs {
 		-- Dependencies
-		dependdir .. "bullet3/include",
 		dependdir .. "glad/include",
 		dependdir .. "ImGui/include",
 		dependdir .. "lua/include",

--- a/Sources/Overload/OvGame/premake5.lua
+++ b/Sources/Overload/OvGame/premake5.lua
@@ -18,8 +18,6 @@ project "OvGame"
 		-- Dependencies
 		dependdir .. "glad/include",
 		dependdir .. "ImGui/include",
-		dependdir .. "lua/include",
-		dependdir .. "sol/include",
 		dependdir .. "tracy",
 
 		-- Overload SDK

--- a/Sources/Overload/OvGame/premake5.lua
+++ b/Sources/Overload/OvGame/premake5.lua
@@ -1,26 +1,82 @@
 project "OvGame"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua", "**.rc" }
+	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
+	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
+	debugdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
+	
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini",
+		"**.rc"
+	}
+
 	includedirs {
-		dependdir .. "glfw/include", dependdir .. "stb_image/include", dependdir .. "lua/include", dependdir .. "sol/include", dependdir .. "bullet3/include", dependdir .. "glad/include", dependdir .. "soloud/include", dependdir .. "ImGui/include", dependdir .. "tinyxml2/include", dependdir .. "tracy",
-		"%{wks.location}/OvAnalytics/include", "%{wks.location}/OvAudio/include", "%{wks.location}/OvCore/include",
-		"%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvPhysics/include",
-		"%{wks.location}/OvRendering/include", "%{wks.location}/OvTools/include", "%{wks.location}/OvUI/include", "%{wks.location}/OvWindowing/include",
+		-- Dependencies
+		dependdir .. "bullet3/include",
+		dependdir .. "glad/include",
+		dependdir .. "ImGui/include",
+		dependdir .. "lua/include",
+		dependdir .. "sol/include",
+		dependdir .. "tracy",
+
+		-- Overload SDK
+		"%{wks.location}/OvAudio/include",
+		"%{wks.location}/OvCore/include",
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvPhysics/include",
+		"%{wks.location}/OvRendering/include",
+		"%{wks.location}/OvTools/include",
+		"%{wks.location}/OvUI/include",
+		"%{wks.location}/OvWindowing/include",
+
+		-- Current project
 		"include"
 	}
 
-	libdirs { dependdir .. "bullet3/lib/%{cfg.buildcfg}", dependdir .. "lua/lib" }
-	links {
-		"Bullet3Collision.lib", "Bullet3Common.lib", "Bullet3Dynamics.lib", "Bullet3Geometry.lib", "BulletCollision.lib", "BulletDynamics.lib", "BulletSoftBody.lib", "LinearMath.lib", "opengl32.lib", "dbghelp.lib",
-		"ImGui", "tinyxml2", "lua", "glad", "glfw", "assimp", "tracy", "soloud",
-		"OvAudio", "OvCore", "OvDebug", "OvMaths", "OvPhysics", "OvRendering", "OvTools", "OvUI", "OvWindowing"
-    }
+	libdirs {
+		dependdir .. "bullet3/lib/%{cfg.buildcfg}",
+		dependdir .. "lua/lib"
+	}
 
-	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
-	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
-	debugdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
+	links {
+		-- Precompiled Libraries
+		"dbghelp.lib",
+		"opengl32.lib",
+		"Bullet3Collision.lib",
+		"Bullet3Common.lib",
+		"Bullet3Dynamics.lib",
+		"Bullet3Geometry.lib",
+		"BulletCollision.lib",
+		"BulletDynamics.lib",
+		"BulletSoftBody.lib",
+		"LinearMath.lib",
+
+		-- Dependencies
+		"assimp",
+		"glad",
+		"glfw",
+		"ImGui",
+		"lua",
+		"soloud",
+		"tinyxml2",
+		"tracy",
+
+		-- Overload SDK
+		"OvAudio",
+		"OvCore",
+		"OvDebug",
+		"OvMaths",
+		"OvPhysics",
+		"OvRendering",
+		"OvTools",
+		"OvUI",
+		"OvWindowing"
+    }
 
 	postbuildcommands {
 		"for /f \"delims=|\" %%i in ('dir /B /S \"%{dependdir}\\*.dll\"') do xcopy /Q /Y \"%%i\" \"%{outputdir}%{cfg.buildcfg}\\%{prj.name}\"",

--- a/Sources/Overload/OvGame/premake5.lua
+++ b/Sources/Overload/OvGame/premake5.lua
@@ -16,7 +16,6 @@ project "OvGame"
 
 	includedirs {
 		-- Dependencies
-		dependdir .. "bullet3/include",
 		dependdir .. "glad/include",
 		dependdir .. "ImGui/include",
 		dependdir .. "lua/include",

--- a/Sources/Overload/OvMaths/premake5.lua
+++ b/Sources/Overload/OvMaths/premake5.lua
@@ -2,11 +2,20 @@ project "OvMaths"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs { "include" }
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Core/PhysicsEngine.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Core/PhysicsEngine.h
@@ -6,9 +6,6 @@
 
 #pragma once
 
-#include <bullet/btBulletCollisionCommon.h>
-#include <bullet/btBulletDynamicsCommon.h>
-
 #include <map>
 #include <optional>
 #include <vector>
@@ -16,6 +13,15 @@
 #include <OvPhysics/Entities/PhysicalObject.h>
 #include <OvPhysics/Entities/RaycastHit.h>
 #include <OvPhysics/Settings/PhysicsSettings.h>
+
+class btDynamicsWorld;
+class btDispatcher;
+class btCollisionConfiguration;
+class btBroadphaseInterface;
+class btConstraintSolver;
+class btRigidBody;
+class btManifoldPoint;
+struct btCollisionObjectWrapper;
 
 namespace OvPhysics::Core
 {
@@ -31,6 +37,11 @@ namespace OvPhysics::Core
 		* @param p_settings
 		*/
 		PhysicsEngine(const Settings::PhysicsSettings& p_settings);
+
+		/**
+		* Destructor
+		*/
+		virtual ~PhysicsEngine() = default;
 
 		/**
 		* Simulate the physics. This method call is decomposed in 3 things:

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Core/PhysicsEngine.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Core/PhysicsEngine.h
@@ -6,13 +6,16 @@
 
 #pragma once
 
-#include <vector>
+#include <bullet/btBulletCollisionCommon.h>
+#include <bullet/btBulletDynamicsCommon.h>
+
 #include <map>
 #include <optional>
+#include <vector>
 
-#include "OvPhysics/Entities/PhysicalObject.h"
-#include "OvPhysics/Settings/PhysicsSettings.h"
-#include "OvPhysics/Entities/RaycastHit.h"
+#include <OvPhysics/Entities/PhysicalObject.h>
+#include <OvPhysics/Entities/RaycastHit.h>
+#include <OvPhysics/Settings/PhysicsSettings.h>
 
 namespace OvPhysics::Core
 {
@@ -71,17 +74,17 @@ namespace OvPhysics::Core
 		void CheckCollisionStopEvents();
 
 		static bool CollisionCallback(btManifoldPoint& cp, const btCollisionObjectWrapper* obj1, int id1, int index1, const btCollisionObjectWrapper* obj2, int id2, int index2);
-		void		SetCollisionCallback();
+		void SetCollisionCallback();
 
 	private:
 		/* Bullet world */
-		std::unique_ptr<btDynamicsWorld>			m_world;
-		std::unique_ptr<btDispatcher>				m_dispatcher;
-		std::unique_ptr<btCollisionConfiguration>	m_collisionConfig;
-		std::unique_ptr<btBroadphaseInterface>		m_broadphase;
-		std::unique_ptr<btConstraintSolver>			m_solver;
+		std::unique_ptr<btDynamicsWorld> m_world;
+		std::unique_ptr<btDispatcher> m_dispatcher;
+		std::unique_ptr<btCollisionConfiguration> m_collisionConfig;
+		std::unique_ptr<btBroadphaseInterface> m_broadphase;
+		std::unique_ptr<btConstraintSolver> m_solver;
 
-		static std::map< std::pair<Entities::PhysicalObject*, Entities::PhysicalObject*>, bool> m_collisionEvents;
-		std::vector<std::reference_wrapper<Entities::PhysicalObject>>							m_physicalObjects;
+		static std::map<std::pair<Entities::PhysicalObject*, Entities::PhysicalObject*>, bool> m_collisionEvents;
+		std::vector<std::reference_wrapper<Entities::PhysicalObject>> m_physicalObjects;
 	};
 }

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Entities/PhysicalObject.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Entities/PhysicalObject.h
@@ -9,17 +9,15 @@
 #include <any>
 #include <memory>
 
-#include <bullet/btBulletCollisionCommon.h>
-#include <bullet/btBulletDynamicsCommon.h>
-
 #include <OvMaths/FTransform.h>
-
 #include <OvTools/Eventing/Event.h>
-
-
-#include "OvPhysics/Settings/BodySettings.h"
+#include <OvPhysics/Settings/BodySettings.h>
 
 namespace OvPhysics::Core { class PhysicsEngine; }
+
+class btCollisionShape;
+class btRigidBody;
+class btMotionState;
 
 namespace OvPhysics::Entities
 {
@@ -85,18 +83,6 @@ namespace OvPhysics::Entities
 		* Clear forces
 		*/
 		void ClearForces();
-
-		/**
-		* Add a flag to the physical object
-		* @param p_flag
-		*/
-		void AddFlag(btCollisionObject::CollisionFlags p_flag);
-
-		/**
-		* Add a flag from the physical object
-		* @param p_flag
-		*/
-		void RemoveFlag(btCollisionObject::CollisionFlags p_flag);
 
 		/**
 		* Returns the mass of the physical object
@@ -256,9 +242,9 @@ namespace OvPhysics::Entities
 
 	private:
 		/* Internal */
-		void								CreateBody(const Settings::BodySettings& p_bodySettings);
-		Settings::BodySettings				DestroyBody();
-		btVector3							CalculateInertia() const;
+		void CreateBody(const Settings::BodySettings& p_bodySettings);
+		Settings::BodySettings DestroyBody();
+		OvMaths::FVector3 CalculateInertia() const;
 
 		/* Needed by the physics engine */
 		btRigidBody&			GetBody();

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Entities/RaycastHit.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Entities/RaycastHit.h
@@ -6,12 +6,9 @@
 
 #pragma once
 
-#include <bullet/btBulletCollisionCommon.h>
-
 #include <vector>
 
-
-#include "OvPhysics/Entities/PhysicalObject.h"
+#include <OvPhysics/Entities/PhysicalObject.h>
 
 namespace OvPhysics::Entities
 {

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Settings/BodySettings.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Settings/BodySettings.h
@@ -6,22 +6,22 @@
 
 #pragma once
 
-#include <bullet/btBulletCollisionCommon.h>
+#include <OvMaths/FVector3.h>
 
 namespace OvPhysics::Settings
 {
 	/**
-	* Usefull to re-create a body using its previous settings
+	* Specifies the settings of a physical body
 	*/
 	struct BodySettings
 	{
-		btVector3 linearVelocity	= { 0.f, 0.f, 0.f };
-		btVector3 angularVelocity	= { 0.f, 0.f, 0.f };
-		btVector3 linearFactor		= { 1, 1, 1 };
-		btVector3 angularFactor		= { 1, 1, 1 };
-		float restitution			= 0.f;
-		float friction				= 0.5f;
-		bool isTrigger				= false;
-		bool isKinematic			= false;
+		OvMaths::FVector3 linearVelocity = OvMaths::FVector3::Zero;
+		OvMaths::FVector3 angularVelocity = OvMaths::FVector3::Zero;
+		OvMaths::FVector3 linearFactor = OvMaths::FVector3::One;
+		OvMaths::FVector3 angularFactor = OvMaths::FVector3::One;
+		float restitution = 0.f;
+		float friction = 0.5f;
+		bool isTrigger = false;
+		bool isKinematic = false;
 	};
 }

--- a/Sources/Overload/OvPhysics/include/OvPhysics/Tools/Conversion.h
+++ b/Sources/Overload/OvPhysics/include/OvPhysics/Tools/Conversion.h
@@ -6,11 +6,13 @@
 
 #pragma once
 
-#include <bullet/btBulletCollisionCommon.h>
-
 #include <OvMaths/FTransform.h>
 #include <OvMaths/FVector3.h>
 #include <OvMaths/FQuaternion.h>
+
+class btTransform;
+class btVector3;
+class btQuaternion;
 
 namespace OvPhysics::Tools
 {

--- a/Sources/Overload/OvPhysics/premake5.lua
+++ b/Sources/Overload/OvPhysics/premake5.lua
@@ -2,15 +2,29 @@ project "OvPhysics"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs { 
-		dependdir .. "bullet3/include",
-		"%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs { 
+		-- Dependencies
+		dependdir .. "bullet3/include",
+
+		-- Overload SDK
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Core/PhysicsEngine.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Core/PhysicsEngine.cpp
@@ -6,16 +6,16 @@
 
 #include <algorithm>
 
-#include "OvPhysics/Core/PhysicsEngine.h"
-#include "OvPhysics/Tools/Conversion.h"
-#include "OvPhysics/Entities/PhysicalObject.h"
-
 #include <OvDebug/Logger.h>
+
+#include <OvPhysics/Core/PhysicsEngine.h>
+#include <OvPhysics/Entities/PhysicalObject.h>
+#include <OvPhysics/Tools/Conversion.h>
 
 using namespace OvPhysics::Tools;
 using namespace OvPhysics::Entities;
 
-std::map< std::pair<PhysicalObject*, PhysicalObject*>, bool> OvPhysics::Core::PhysicsEngine::m_collisionEvents;
+std::map<std::pair<PhysicalObject*, PhysicalObject*>, bool> OvPhysics::Core::PhysicsEngine::m_collisionEvents;
 
 OvPhysics::Core::PhysicsEngine::PhysicsEngine(const Settings::PhysicsSettings & p_settings)
 {

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Core/PhysicsEngine.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Core/PhysicsEngine.cpp
@@ -6,6 +6,9 @@
 
 #include <algorithm>
 
+#include <bullet/btBulletCollisionCommon.h>
+#include <bullet/btBulletDynamicsCommon.h>
+
 #include <OvDebug/Logger.h>
 
 #include <OvPhysics/Core/PhysicsEngine.h>

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalBox.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalBox.cpp
@@ -4,8 +4,10 @@
 * @licence: MIT
 */
 
-#include "OvPhysics/Entities/PhysicalBox.h"
-#include "OvPhysics/Tools/Conversion.h"
+#include <bullet/btBulletCollisionCommon.h>
+
+#include <OvPhysics/Entities/PhysicalBox.h>
+#include <OvPhysics/Tools/Conversion.h>
 
 OvPhysics::Entities::PhysicalBox::PhysicalBox(const OvMaths::FVector3& p_size) : PhysicalObject()
 {

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalCapsule.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalCapsule.cpp
@@ -6,8 +6,10 @@
 
 #include <algorithm>
 
-#include "OvPhysics/Entities/PhysicalCapsule.h"
-#include "OvPhysics/Tools/Conversion.h"
+#include <bullet/btBulletCollisionCommon.h>
+
+#include <OvPhysics/Entities/PhysicalCapsule.h>
+#include <OvPhysics/Tools/Conversion.h>
 
 OvPhysics::Entities::PhysicalCapsule::PhysicalCapsule(float p_radius, float p_height) : PhysicalObject()
 {

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalSphere.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Entities/PhysicalSphere.cpp
@@ -6,7 +6,9 @@
 
 #include <algorithm>
 
-#include "OvPhysics/Entities/PhysicalSphere.h"
+#include <bullet/btBulletCollisionCommon.h>
+
+#include <OvPhysics/Entities/PhysicalSphere.h>
 
 OvPhysics::Entities::PhysicalSphere::PhysicalSphere(float p_radius) : PhysicalObject()
 {

--- a/Sources/Overload/OvPhysics/src/OvPhysics/Tools/Conversion.cpp
+++ b/Sources/Overload/OvPhysics/src/OvPhysics/Tools/Conversion.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvPhysics/Tools/Conversion.h"
+#include <bullet/LinearMath/btTransform.h>
+
+#include <OvPhysics/Tools/Conversion.h>
 
 btTransform OvPhysics::Tools::Conversion::ToBtTransform(const OvMaths::FTransform& p_transform)
 {

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLVertexBuffer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/OpenGL/GLVertexBuffer.h
@@ -8,7 +8,6 @@
 
 #include <OvRendering/HAL/Common/TVertexBuffer.h>
 #include <OvRendering/HAL/OpenGL/GLBuffer.h>
-#include <OvRendering/HAL/OpenGL/GLTypes.h>
 
 namespace OvRendering::HAL
 {

--- a/Sources/Overload/OvRendering/include/OvRendering/HAL/Profiling.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/HAL/Profiling.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #if defined(GRAPHICS_API_OPENGL)
+#include <glad.h>
 #include <tracy/TracyOpenGL.hpp>
 #else
 #undef TRACY_ENABLE // Disable tracy GPU profiling if not using OpenGL

--- a/Sources/Overload/OvRendering/premake5.lua
+++ b/Sources/Overload/OvRendering/premake5.lua
@@ -2,15 +2,32 @@ project "OvRendering"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		dependdir .. "glad/include", dependdir .. "stb_image/include", dependdir .. "assimp/include", dependdir .. "tracy",
-		"%{wks.location}/OvDebug/include", "%{wks.location}/OvMaths/include", "%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "assimp/include",
+		dependdir .. "glad/include",
+		dependdir .. "stb_image/include",
+		dependdir .. "tracy",
+
+		-- Overload SDK
+		"%{wks.location}/OvDebug/include",
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvTools/premake5.lua
+++ b/Sources/Overload/OvTools/premake5.lua
@@ -2,14 +2,27 @@ project "OvTools"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		dependdir .. "tracy",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "tracy",
+
+		-- Current Project
+		"include"
+	}
+
+	filter { "system:windows" }
+		characterset ("MBCS")
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvUI/include/OvUI/Settings/EDirection.h
+++ b/Sources/Overload/OvUI/include/OvUI/Settings/EDirection.h
@@ -1,0 +1,21 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <cstdint>
+
+namespace OvUI::Settings
+{
+	enum class EDirection : uint8_t
+	{
+		NONE = 0,
+		LEFT = 1,
+		RIGHT = 2,
+		UP = 3,
+		DOWN = 4,
+	};
+}

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/AWidget.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/AWidget.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <imgui.h>
-
 #include <string>
 
 #include <OvUI/API/IDrawable.h>

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonArrow.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Buttons/ButtonArrow.h
@@ -8,7 +8,8 @@
 
 #include <string>
 
-#include "OvUI/Widgets/Buttons/AButton.h"
+#include <OvUI/Settings/EDirection.h>
+#include <OvUI/Widgets/Buttons/AButton.h>
 
 namespace OvUI::Widgets::Buttons
 {
@@ -22,12 +23,12 @@ namespace OvUI::Widgets::Buttons
 		* Create the button
 		* @param p_direction
 		*/
-		ButtonArrow(ImGuiDir p_direction = ImGuiDir_None);
+		ButtonArrow(Settings::EDirection p_direction = Settings::EDirection::NONE);
 
 	protected:
 		void _Draw_Impl() override;
 
 	public:
-		ImGuiDir direction;
+		Settings::EDirection direction;
 	};
 }

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragSingleScalar.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Drags/DragSingleScalar.h
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <imgui.h>
+
 #include <OvTools/Eventing/Event.h>
 
-#include "OvUI/Widgets/DataWidget.h"
+#include <OvUI/Widgets/DataWidget.h>
 
 namespace OvUI::Widgets::Drags
 {

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/InputFields/InputSingleScalar.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/InputFields/InputSingleScalar.h
@@ -6,9 +6,10 @@
 
 #pragma once
 
-#include <OvTools/Eventing/Event.h>
+#include <imgui.h>
 
-#include "OvUI/Widgets/DataWidget.h"
+#include <OvTools/Eventing/Event.h>
+#include <OvUI/Widgets/DataWidget.h>
 
 namespace OvUI::Widgets::InputFields
 {

--- a/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Columns.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/Layout/Columns.h
@@ -7,8 +7,9 @@
 #pragma once
 
 #include <array>
+#include <imgui.h>
 
-#include "OvUI/Internal/WidgetContainer.h"
+#include <OvUI/Internal/WidgetContainer.h>
 
 namespace OvUI::Widgets::Layout
 {

--- a/Sources/Overload/OvUI/premake5.lua
+++ b/Sources/Overload/OvUI/premake5.lua
@@ -2,15 +2,28 @@ project "OvUI"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		dependdir .. "glfw/include", dependdir .. "glad/include", dependdir .. "ImGui/include",
-		"%{wks.location}/OvMaths/include", "%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "ImGui/include",
+
+		-- Overload SDK
+		"%{wks.location}/OvMaths/include",
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelMenuBar.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelMenuBar.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Panels/PanelMenuBar.h"
+#include <imgui.h>
+
+#include <OvUI/Panels/PanelMenuBar.h>
 
 void OvUI::Panels::PanelMenuBar::_Draw_Impl()
 {

--- a/Sources/Overload/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Panels/PanelUndecorated.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Panels/PanelUndecorated.h"
+#include <imgui.h>
+
+#include <OvUI/Panels/PanelUndecorated.h>
 
 void OvUI::Panels::PanelUndecorated::_Draw_Impl()
 {

--- a/Sources/Overload/OvUI/src/OvUI/Plugins/ContextualMenu.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Plugins/ContextualMenu.cpp
@@ -4,6 +4,8 @@
 * @licence: MIT
 */
 
+#include <imgui.h>
+
 #include <OvUI/Panels/APanel.h>
 #include <OvUI/Plugins/ContextualMenu.h>
 

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/AWidget.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/AWidget.h>
 
 uint64_t OvUI::Widgets::AWidget::__WIDGET_ID_INCREMENT = 0;
 

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Buttons/ButtonArrow.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Buttons/ButtonArrow.cpp
@@ -4,15 +4,34 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Buttons/ButtonArrow.h"
+#include <imgui.h>
 
-OvUI::Widgets::Buttons::ButtonArrow::ButtonArrow(ImGuiDir p_direction) :
+#include <OvTools/Utils/EnumMapper.h>
+#include <OvUI/Widgets/Buttons/ButtonArrow.h>
+
+template <>
+struct OvTools::Utils::MappingFor<OvUI::Settings::EDirection, ImGuiDir>
+{
+	using enum ImGuiDir;
+	using EnumType = OvUI::Settings::EDirection;
+	using type = std::tuple<
+		EnumValuePair<EnumType::NONE, ImGuiDir_None>,
+		EnumValuePair<EnumType::LEFT, ImGuiDir_Left>,
+		EnumValuePair<EnumType::RIGHT, ImGuiDir_Right>,
+		EnumValuePair<EnumType::UP, ImGuiDir_Up>,
+		EnumValuePair<EnumType::DOWN, ImGuiDir_Down>
+	>;
+};
+
+OvUI::Widgets::Buttons::ButtonArrow::ButtonArrow(Settings::EDirection p_direction) :
 	direction(p_direction)
 {
 }
 
 void OvUI::Widgets::Buttons::ButtonArrow::_Draw_Impl()
 {
-	if (ImGui::ArrowButton(m_widgetID.c_str(), direction))
+	if (ImGui::ArrowButton(m_widgetID.c_str(), OvTools::Utils::ToValueImpl<Settings::EDirection, ImGuiDir>(direction)))
+	{
 		ClickedEvent.Invoke();
+	}
 }

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/InputFields/InputText.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/InputFields/InputText.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/InputFields/InputText.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/InputFields/InputText.h>
 
 OvUI::Widgets::InputFields::InputText::InputText(const std::string& p_content, const std::string& p_label) :
 	DataWidget<std::string>(content), content(p_content), label(p_label)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/NewLine.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/NewLine.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Layout/NewLine.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Layout/NewLine.h>
 
 void OvUI::Widgets::Layout::NewLine::_Draw_Impl()
 {

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/Spacing.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/Spacing.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Layout/Spacing.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Layout/Spacing.h>
 
 OvUI::Widgets::Layout::Spacing::Spacing(uint16_t p_spaces) : spaces(p_spaces)
 {

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Layout/TreeNode.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Layout/TreeNode.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Layout/TreeNode.h>
 
 OvUI::Widgets::Layout::TreeNode::TreeNode(const std::string & p_name, bool p_arrowClickToOpen) :
 	DataWidget(name),

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Menu/MenuItem.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Menu/MenuItem.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Menu/MenuItem.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Menu/MenuItem.h>
 
 OvUI::Widgets::Menu::MenuItem::MenuItem(const std::string & p_name, const std::string & p_shortcut, bool p_checkable, bool p_checked) :
 	DataWidget(m_selected), name(p_name), shortcut(p_shortcut), checkable(p_checkable), checked(p_checked)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Menu/MenuList.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Menu/MenuList.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Menu/MenuList.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Menu/MenuList.h>
 
 OvUI::Widgets::Menu::MenuList::MenuList(const std::string & p_name, bool p_locked) :
 	name(p_name), locked(p_locked)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/CheckBox.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/CheckBox.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Selection/CheckBox.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Selection/CheckBox.h>
 
 OvUI::Widgets::Selection::CheckBox::CheckBox(bool p_value, const std::string & p_label) :
 	DataWidget<bool>(value), value(p_value), label(p_label)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ColorEdit.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ColorEdit.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Selection/ColorEdit.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Selection/ColorEdit.h>
 
 OvUI::Widgets::Selection::ColorEdit::ColorEdit(bool p_enableAlpha, const Types::Color & p_defaultColor) :
 	DataWidget<Types::Color>(color), enableAlpha(p_enableAlpha), color(p_defaultColor)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ColorPicker.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ColorPicker.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Selection/ColorPicker.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Selection/ColorPicker.h>
 
 OvUI::Widgets::Selection::ColorPicker::ColorPicker(bool p_enableAlpha, const Types::Color & p_defaultColor) :
 	DataWidget<Types::Color>(color), enableAlpha(p_enableAlpha), color(p_defaultColor)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ComboBox.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/ComboBox.cpp
@@ -5,8 +5,9 @@
 */
 
 #include <algorithm>
+#include <imgui.h>
 
-#include "OvUI/Widgets/Selection/ComboBox.h"
+#include <OvUI/Widgets/Selection/ComboBox.h>
 
 OvUI::Widgets::Selection::ComboBox::ComboBox(int p_currentChoice) :
 	DataWidget<int>(currentChoice), currentChoice(p_currentChoice)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/RadioButton.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Selection/RadioButton.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Selection/RadioButton.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Selection/RadioButton.h>
 
 OvUI::Widgets::Selection::RadioButton::RadioButton(bool p_selected, const std::string & p_label) :
 	DataWidget<bool>(m_selected), label(p_label)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/Text.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/Text.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/Text.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/Text.h>
 
 OvUI::Widgets::Texts::Text::Text(const std::string & p_content) :
 	DataWidget(content),

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextClickable.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextClickable.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/TextClickable.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/TextClickable.h>
 
 OvUI::Widgets::Texts::TextClickable::TextClickable(const std::string & p_content) :
 	Text(p_content)
@@ -15,15 +17,15 @@ void OvUI::Widgets::Texts::TextClickable::_Draw_Impl()
 {
 	bool useless = false;
 
-    if (ImGui::Selectable((content + m_widgetID).c_str(), &useless, ImGuiSelectableFlags_AllowDoubleClick))
-    {
-        if (ImGui::IsMouseDoubleClicked(0))
-        {
-            DoubleClickedEvent.Invoke();
-        }
-        else
-        {
-            ClickedEvent.Invoke();
-        }
-    }
+	if (ImGui::Selectable((content + m_widgetID).c_str(), &useless, ImGuiSelectableFlags_AllowDoubleClick))
+	{
+		if (ImGui::IsMouseDoubleClicked(0))
+		{
+			DoubleClickedEvent.Invoke();
+		}
+		else
+		{
+			ClickedEvent.Invoke();
+		}
+	}
 }

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextDisabled.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextDisabled.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/TextDisabled.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/TextDisabled.h>
 
 OvUI::Widgets::Texts::TextDisabled::TextDisabled(const std::string & p_content) :
 	Text(p_content)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextLabelled.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextLabelled.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/TextLabelled.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/TextLabelled.h>
 
 OvUI::Widgets::Texts::TextLabelled::TextLabelled(const std::string& p_content, const std::string& p_label) :
 	Text(p_content), label(p_label)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextSelectable.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextSelectable.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/TextSelectable.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/TextSelectable.h>
 
 OvUI::Widgets::Texts::TextSelectable::TextSelectable(const std::string & p_content, bool p_selected, bool p_disabled) :
 	Text(p_content), selected(p_selected), disabled(p_disabled)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextWrapped.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Texts/TextWrapped.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Texts/TextWrapped.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Texts/TextWrapped.h>
 
 OvUI::Widgets::Texts::TextWrapped::TextWrapped(const std::string & p_content) :
 	Text(p_content)

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Visual/Bullet.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Visual/Bullet.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Visual/Bullet.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Visual/Bullet.h>
 
 void OvUI::Widgets::Visual::Bullet::_Draw_Impl()
 {

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/Visual/Separator.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/Visual/Separator.cpp
@@ -4,7 +4,9 @@
 * @licence: MIT
 */
 
-#include "OvUI/Widgets/Visual/Separator.h"
+#include <imgui.h>
+
+#include <OvUI/Widgets/Visual/Separator.h>
 
 void OvUI::Widgets::Visual::Separator::_Draw_Impl()
 {

--- a/Sources/Overload/OvWindowing/premake5.lua
+++ b/Sources/Overload/OvWindowing/premake5.lua
@@ -2,15 +2,31 @@ project "OvWindowing"
 	kind "StaticLib"
 	language "C++"
 	cppdialect "C++20"
-	files { "**.h", "**.inl", "**.cpp", "**.lua" }
-	includedirs {
-		dependdir .. "glfw/include", dependdir .. "stb_image/include",
-		"%{wks.location}/OvTools/include",
-		"include"
-	}
 	targetdir (outputdir .. "%{cfg.buildcfg}/%{prj.name}")
 	objdir (objoutdir .. "%{cfg.buildcfg}/%{prj.name}")
-	characterset ("MBCS")
+
+	files {
+		"**.h",
+		"**.inl",
+		"**.cpp",
+		"**.lua",
+		"**.ini"
+	}
+
+	includedirs {
+		-- Dependencies
+		dependdir .. "glfw/include",
+		dependdir .. "stb_image/include",
+
+		-- Overload SDK
+		"%{wks.location}/OvTools/include",
+
+		-- Current Project
+		"include"
+	}
+
+	filter { "system:windows" }
+		characterset ("MBCS")
 
 	filter { "configurations:Debug" }
 		defines { "DEBUG" }


### PR DESCRIPTION
## Description
* Updated `premake5.lua` files to be more consistent
  * Revised layout to improve readability/maintainability
  * Removed unnecessary includes (some projects where referencing some include dirs that they weren't actually using)
* Moved (some) include statements from header files to source files and added forward declarations
  * This removes the need for a project (A) including another project (B) to have to also include dependencies from the other project (B)
* Removed `characterset ("MBCS")` from a few libs (some still use some Windows-specific code that requires it), as this option isn't recommended anymore (unicode now preferred)
* Disable warnings from dependencies (remove unnecessary noise)

## Related Issues
Fixes https://github.com/Overload-Technologies/Overload/issues/461
Fixes https://github.com/Overload-Technologies/Overload/issues/465

## Notes
As a side effect, these changes also improved build times:

### Locally (Ryzen 9 3900x)
Before:
```
========== Build: 19 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
========== Build completed at 5:54 PM and took 04:37.363 minutes ==========
```

After:
```
========== Build: 19 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
========== Build completed at 5:48 PM and took 03:14.134 minutes ==========
```

### Build Machine (GitHub)
On the build machine (GitHub workflow), it went down from **9m54** to **8m15s**.
