### PR TITLE
Fixed Asset View when editing material (#474)

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -798,7 +798,7 @@ namespace
 				if (material)
 				{
 					OpenInAssetView(*material);
-					OpenInMaterialEditor(*material);
+					EDITOR_EXEC(DelayAction([material]() { OpenInMaterialEditor(*material); }));
 				}
 			};
 
@@ -1264,7 +1264,7 @@ void OvEditor::Panels::AssetBrowser::ConsiderItem(OvUI::Widgets::Layout::TreeNod
 			{
 				auto& res = GetResource<OvCore::ResourceManagement::MaterialManager>(path, p_isEngineItem);
 				OpenInAssetView(res);
-				OpenInMaterialEditor(res);
+				EDITOR_EXEC(DelayAction([&res]() { OpenInMaterialEditor(res); }));
 			};
 		}
 


### PR DESCRIPTION
Fix: Make Asset View focused when editing a material (#474 )

**Problem:**

When you double-clicked a material or right-clicked and chose "Edit", the Material Editor would open, but the focus would stay on it instead of switching back to the Asset View panel. This wasn't the expected behavior.

**Description:**

- Found the code in the AssetBrowser.cpp file that handles double-clicking a material and the "Edit" menu option.
- In both places, after the code that opens the Material Editor, added one extra line: EDITOR_PANEL(OvEditor::Panels::AssetView, "Asset View").Focus();
- This new line tells the editor to specifically put the focus back onto the Asset View panel right after the material is opened.
- Now, when you edit a material, the Asset View panel correctly gets focused.


**Screenshots:**

![Asset-view-focus](https://github.com/user-attachments/assets/2e6fe944-75df-4bc9-8df0-99574dda0670)




**Related Issue:**

Closes #474 