### PR TITLE
Added back hierarchy search bar

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/Hierarchy.h
@@ -85,5 +85,7 @@ namespace OvEditor::Panels
 
 	private:
 		std::unordered_map<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*> m_widgetActorLink;
+		OvUI::Internal::WidgetContainer& m_actions;
+		OvUI::Internal::WidgetContainer& m_actors;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -144,9 +144,12 @@ OvEditor::Panels::Hierarchy::Hierarchy
 	const std::string & p_title,
 	bool p_opened,
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
-) : PanelWindow(p_title, p_opened, p_windowSettings)
+) :
+	PanelWindow(p_title, p_opened, p_windowSettings),
+	m_actions(CreateWidget<OvUI::Widgets::Layout::Group>()),
+	m_actors(CreateWidget<OvUI::Widgets::Layout::Group>())
 {
-	auto& searchBar = CreateWidget<OvUI::Widgets::InputFields::InputText>();
+	auto& searchBar = m_actions.CreateWidget<OvUI::Widgets::InputFields::InputText>();
 	searchBar.ContentChangedEvent += [this](const std::string& p_content)
 	{
 		founds.clear();
@@ -227,7 +230,7 @@ void OvEditor::Panels::Hierarchy::Clear()
 {
 	EDITOR_EXEC(UnselectActor());
 
-	RemoveAllWidgets();
+	m_actors.RemoveAllWidgets();
 	m_widgetActorLink.clear();
 }
 
@@ -329,7 +332,7 @@ void OvEditor::Panels::Hierarchy::DeleteActorByInstance(OvCore::ECS::Actor& p_ac
 
 void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_actor)
 {
-	auto& textSelectable = CreateWidget<OvUI::Widgets::Layout::TreeNode>(p_actor.GetName(), true);
+	auto& textSelectable = m_actors.CreateWidget<OvUI::Widgets::Layout::TreeNode>(p_actor.GetName(), true);
 	textSelectable.leaf = true;
 	textSelectable.AddPlugin<ActorContextualMenu>(&p_actor, &textSelectable);
 	textSelectable.AddPlugin<OvUI::Plugins::DDSource<std::pair<OvCore::ECS::Actor*, OvUI::Widgets::Layout::TreeNode*>>>("Actor", "Attach to...", std::make_pair(&p_actor, &textSelectable));


### PR DESCRIPTION
## Description
* Added back the missing hierarchy search bar.
  * The hierarchy was clearing ALL widgets, causing the issue
  * Hierarchy widgets are now separated into 2 groups: `m_actions` and `m_actors`

## Related Issues
Fixes https://github.com/Overload-Technologies/Overload/issues/442

## Screenshots
![image](https://github.com/user-attachments/assets/69c711a9-71bf-4884-b9ba-af7dacb5b120)
