### PR TITLE
Updated OvWindowing so it has the last say on the cursor shape

### DIFF
--- a/Sources/Overload/OvWindowing/include/OvWindowing/Window.h
+++ b/Sources/Overload/OvWindowing/include/OvWindowing/Window.h
@@ -7,11 +7,12 @@
 #pragma once
 
 #include <string>
+#include <optional>
 
-#include "OvWindowing/Context/Device.h"
-#include "OvWindowing/Settings/WindowSettings.h"
-#include "OvWindowing/Cursor/ECursorShape.h"
-#include "OvWindowing/Cursor/ECursorMode.h"
+#include <OvWindowing/Context/Device.h>
+#include <OvWindowing/Cursor/ECursorShape.h>
+#include <OvWindowing/Cursor/ECursorMode.h>
+#include <OvWindowing/Settings/WindowSettings.h>
 
 namespace OvWindowing
 {
@@ -201,9 +202,10 @@ namespace OvWindowing
 		void MakeCurrentContext() const;
 
 		/**
-		* Handle the buffer swapping with the current window
+		* Handle the buffer swapping with the current window.
+		* @note Also responsible for updating the cursor, so it's done last and has the final word
 		*/
-		void SwapBuffers() const;
+		void SwapBuffers();
 
 		/**
 		* Define a mode for the mouse cursor
@@ -212,8 +214,10 @@ namespace OvWindowing
 		void SetCursorMode(Cursor::ECursorMode p_cursorMode);
 
 		/**
-		* Define a shape to apply to the current cursor
+		* Define a shape to apply to the current cursor.
 		* @param p_cursorShape
+		* @note the cursor will only update on the next SwapBuffers call, this is so that OvWindowing has the final word.
+		* @note when using ImGui, this needs to be called every frame to update the cursor shape
 		*/
 		void SetCursorShape(Cursor::ECursorShape p_cursorShape);
 
@@ -273,11 +277,6 @@ namespace OvWindowing
 		Cursor::ECursorMode GetCursorMode() const;
 
 		/**
-		* Return the current cursor shape
-		*/
-		Cursor::ECursorShape GetCursorShape() const;
-
-		/**
 		* Return the current refresh rate (Only applied to the fullscreen mode).
 		* If the value is -1 (WindowSettings::DontCare) the highest refresh rate will be used
 		*/
@@ -326,6 +325,6 @@ namespace OvWindowing
 		bool m_fullscreen;
 		int32_t m_refreshRate;
 		Cursor::ECursorMode m_cursorMode;
-		Cursor::ECursorShape m_cursorShape;
+		std::optional<Cursor::ECursorShape> m_cursorShape;
 	};
 }

--- a/Sources/Overload/OvWindowing/src/OvWindowing/Window.cpp
+++ b/Sources/Overload/OvWindowing/src/OvWindowing/Window.cpp
@@ -215,8 +215,14 @@ void OvWindowing::Window::MakeCurrentContext() const
 	glfwMakeContextCurrent(m_glfwWindow);
 }
 
-void OvWindowing::Window::SwapBuffers() const
+void OvWindowing::Window::SwapBuffers()
 {
+	if (m_cursorShape.has_value())
+	{
+		glfwSetCursor(m_glfwWindow, m_device.GetCursorInstance(m_cursorShape.value()));
+		m_cursorShape.reset();
+	}
+
 	glfwSwapBuffers(m_glfwWindow);
 }
 
@@ -229,7 +235,6 @@ void OvWindowing::Window::SetCursorMode(Cursor::ECursorMode p_cursorMode)
 void OvWindowing::Window::SetCursorShape(Cursor::ECursorShape p_cursorShape)
 {
 	m_cursorShape = p_cursorShape;
-	glfwSetCursor(m_glfwWindow, m_device.GetCursorInstance(p_cursorShape));
 }
 
 void OvWindowing::Window::SetCursorPosition(int16_t p_x, int16_t p_y)
@@ -287,11 +292,6 @@ std::pair<uint16_t, uint16_t> OvWindowing::Window::GetFramebufferSize() const
 OvWindowing::Cursor::ECursorMode OvWindowing::Window::GetCursorMode() const
 {
 	return m_cursorMode;
-}
-
-OvWindowing::Cursor::ECursorShape OvWindowing::Window::GetCursorShape() const
-{
-	return m_cursorShape;
 }
 
 int32_t OvWindowing::Window::GetRefreshRate() const


### PR DESCRIPTION
## Description
ImGui has the last say on which cursor shape to use. This leads to cursor overrides like using the `HAND` cursor for panning to be ignored.

This PR changes that by making the `Window::SetCursorShape()` have the last word, meaning that the cursor will be set to the given shape at the next `Window::SwapBuffers()` call. When `OvWindowing` is used with `ImGui`, `Window::SetCursorShape()` will need to be called every frame to counteract `ImGui` behaviour (ImGui updates the cursor every frame internally).

Also removed `GetCursorShape()` as it's unreliable, given that `ImGui` might modify the cursor too, and `GetCursorShape()` wouldn't be able to track that.

## Screenshots


https://github.com/user-attachments/assets/e8437484-c3c4-4c69-a0dc-d4f4cd859880

_Notice the hand cursor now properly shows_