### PR TITLE
Materials can now be dropped onto an actor

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/SceneView.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/SceneView.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include "OvEditor/Panels/AViewControllable.h"
-#include "OvEditor/Core/GizmoBehaviour.h"
+#include <OvEditor/Core/GizmoBehaviour.h>
+#include <OvEditor/Panels/AViewControllable.h>
+#include <OvEditor/Rendering/PickingRenderPass.h>
 
 namespace OvEditor::Panels
 {
@@ -47,6 +48,10 @@ namespace OvEditor::Panels
 	private:
 		virtual void DrawFrame() override;
 		void HandleActorPicking();
+		OvEditor::Rendering::PickingRenderPass::PickingResult GetPickingResult();
+		void OnSceneDropped(const std::string& p_path);
+		void OnModelDropped(const std::string& p_path);
+		void OnMaterialDropped(const std::string& p_path);
 
 	private:
 		OvCore::SceneSystem::SceneManager& m_sceneManager;


### PR DESCRIPTION
## Description
Materials can now be dropped onto an actor in the scene view!

## Review Guidance
- Cleaned up the picking code so that it can be reused to detect what actor is under the mouse cursor outside of the picking handling for selection.
- Added proper methods to handle the different drop actions (`OnSceneDropped`, `OnModelDropped`, `OnMaterialDropped`)

## Limitations
- Only the material at index `0` in the `MaterialRenderer` will be affected.
- No preview of which object is going to be affected.
- No preview of the material on the object before it's applied (like Unity would do). The UX wouldn't be so great if we added that, since we only load resource synchronously. This would lead to the editor stuttering before dropping.

## Related Issues
Fixes #97 

## Screenshots

https://github.com/user-attachments/assets/73fcdde9-1f96-4050-ad84-00f17fe683c1


