### PR TITLE
Added support for HDR textures

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
@@ -18,7 +18,6 @@ namespace
 		OvRendering::Settings::ETextureFilteringMode minFilter;
 		OvRendering::Settings::ETextureFilteringMode magFilter;
 		bool generateMipmap;
-		bool hdr;
 	};
 
 	TextureMetaData LoadTextureMetadata(const std::string_view p_filePath)
@@ -31,8 +30,7 @@ namespace
 		return TextureMetaData{
 			.minFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MIN_FILTER", static_cast<int>(LINEAR_MIPMAP_LINEAR))),
 			.magFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MAG_FILTER", static_cast<int>(LINEAR))),
-			.generateMipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true),
-			.hdr = metaFile.GetOrDefault("HDR", false)
+			.generateMipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true)
 		};
 	}
 }
@@ -47,8 +45,7 @@ OvRendering::Resources::Texture* OvCore::ResourceManagement::TextureManager::Cre
 		realPath,
 		metaData.minFilter,
 		metaData.magFilter,
-		metaData.generateMipmap,
-		metaData.hdr
+		metaData.generateMipmap
 	);
 
 	if (texture)
@@ -73,7 +70,6 @@ void OvCore::ResourceManagement::TextureManager::ReloadResource(OvRendering::Res
 		realPath,
 		metaData.minFilter,
 		metaData.magFilter,
-		metaData.generateMipmap,
-		metaData.hdr
+		metaData.generateMipmap
 	);
 }

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
@@ -4,29 +4,53 @@
 * @licence: MIT
 */
 
-#include "OvCore/ResourceManagement/TextureManager.h"
-#include "OvRendering/Settings/DriverSettings.h"
+#include <format>
+
+#include <OvCore/ResourceManagement/TextureManager.h>
+#include <OvRendering/Settings/DriverSettings.h>
 
 #include <OvTools/Filesystem/IniFile.h>
 
-std::tuple<OvRendering::Settings::ETextureFilteringMode, OvRendering::Settings::ETextureFilteringMode, bool> GetAssetMetadata(const std::string& p_path)
+namespace
 {
-	auto metaFile = OvTools::Filesystem::IniFile(p_path + ".meta");
+	struct TextureMetaData
+	{
+		OvRendering::Settings::ETextureFilteringMode minFilter;
+		OvRendering::Settings::ETextureFilteringMode magFilter;
+		bool generateMipmap;
+		bool hdr;
+	};
 
-	auto min = metaFile.GetOrDefault("MIN_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
-	auto mag = metaFile.GetOrDefault("MAG_FILTER", static_cast<int>(OvRendering::Settings::ETextureFilteringMode::LINEAR));
-	auto mipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true);
+	TextureMetaData LoadTextureMetadata(const std::string_view p_filePath)
+	{
+		using namespace OvRendering::Settings;
+		using enum ETextureFilteringMode;
 
-	return { static_cast<OvRendering::Settings::ETextureFilteringMode>(min), static_cast<OvRendering::Settings::ETextureFilteringMode>(mag), mipmap };
+		const auto metaFile = OvTools::Filesystem::IniFile(std::format("{}.meta", p_filePath));
+
+		return TextureMetaData{
+			.minFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MIN_FILTER", static_cast<int>(LINEAR_MIPMAP_LINEAR))),
+			.magFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MAG_FILTER", static_cast<int>(LINEAR))),
+			.generateMipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true),
+			.hdr = metaFile.GetOrDefault("HDR", false)
+		};
+	}
 }
 
 OvRendering::Resources::Texture* OvCore::ResourceManagement::TextureManager::CreateResource(const std::string & p_path)
 {
 	std::string realPath = GetRealPath(p_path);
 
-	auto [min, mag, mipmap] = GetAssetMetadata(realPath);
+	const auto metaData = LoadTextureMetadata(realPath);
 
-	OvRendering::Resources::Texture* texture = OvRendering::Resources::Loaders::TextureLoader::Create(realPath, min, mag, mipmap);
+	OvRendering::Resources::Texture* texture = OvRendering::Resources::Loaders::TextureLoader::Create(
+		realPath,
+		metaData.minFilter,
+		metaData.magFilter,
+		metaData.generateMipmap,
+		metaData.hdr
+	);
+
 	if (texture)
 		*reinterpret_cast<std::string*>(reinterpret_cast<char*>(texture) + offsetof(OvRendering::Resources::Texture, path)) = p_path; // Force the resource path to fit the given path
 
@@ -42,7 +66,14 @@ void OvCore::ResourceManagement::TextureManager::ReloadResource(OvRendering::Res
 {
 	std::string realPath = GetRealPath(p_path);
 
-	auto [min, mag, mipmap] = GetAssetMetadata(realPath);
+	const auto metaData = LoadTextureMetadata(realPath);
 
-	OvRendering::Resources::Loaders::TextureLoader::Reload(*p_resource, realPath, min, mag, mipmap);
+	OvRendering::Resources::Loaders::TextureLoader::Reload(
+		*p_resource,
+		realPath,
+		metaData.minFilter,
+		metaData.magFilter,
+		metaData.generateMipmap,
+		metaData.hdr
+	);
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -683,7 +683,7 @@ bool OvEditor::Core::EditorActions::ImportAssetAtLocation(const std::string& p_d
 	using namespace OvWindowing::Dialogs;
 
 	std::string modelFormats = "*.fbx;*.obj;";
-	std::string textureFormats = "*.png;*.jpeg;*.jpg;*.tga;";
+	std::string textureFormats = "*.png;*.jpeg;*.jpg;*.tga;*.hdr";
 	std::string shaderFormats = "*.ovfx";
 	std::string shaderPartFormats = "*.ovfxh";
 	std::string soundFormats = "*.mp3;*.ogg;*.wav;";
@@ -691,7 +691,7 @@ bool OvEditor::Core::EditorActions::ImportAssetAtLocation(const std::string& p_d
 	OpenFileDialog selectAssetDialog("Select an asset to import");
 	selectAssetDialog.AddFileType("Any supported format", modelFormats + textureFormats + shaderFormats + soundFormats);
 	selectAssetDialog.AddFileType("Model (.fbx, .obj)", modelFormats);
-	selectAssetDialog.AddFileType("Texture (.png, .jpeg, .jpg, .tga)", textureFormats);
+	selectAssetDialog.AddFileType("Texture (.png, .jpeg, .jpg, .tga, .hdr)", textureFormats);
 	selectAssetDialog.AddFileType("Shader (.ovfx)", shaderFormats);
 	selectAssetDialog.AddFileType("Shader Parts (.ovfxh)", shaderPartFormats);
 	selectAssetDialog.AddFileType("Sound (.mp3, .ogg, .wav)", soundFormats);

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -282,10 +282,12 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 	const std::string kMinFilter = "MIN_FILTER";
 	const std::string kMagFilter = "MAG_FILTER";
 	const std::string kEnableMipmapping = "ENABLE_MIPMAPPING";
+	const std::string kHDR = "HDR";
 
 	m_metadata->Add(kMinFilter, static_cast<int>(ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
 	m_metadata->Add(kMagFilter, static_cast<int>(ETextureFilteringMode::LINEAR));
 	m_metadata->Add(kEnableMipmapping, true);
+	m_metadata->Add(kHDR, false);
 
 	const auto filteringModes = std::map<int, std::string>{
 		{static_cast<int>(ETextureFilteringMode::NEAREST), "NEAREST"},
@@ -318,6 +320,15 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 		},
 		[this, kEnableMipmapping](bool value) {
 			m_metadata->Set<bool>(kEnableMipmapping, value);
+		}
+	);
+
+	OvCore::Helpers::GUIDrawer::DrawBoolean(*m_settingsColumns, kHDR,
+		[this, kHDR]() {
+			return m_metadata->Get<bool>(kHDR);
+		},
+		[this, kHDR](bool value) {
+			m_metadata->Set<bool>(kHDR, value);
 		}
 	);
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -282,12 +282,10 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 	const std::string kMinFilter = "MIN_FILTER";
 	const std::string kMagFilter = "MAG_FILTER";
 	const std::string kEnableMipmapping = "ENABLE_MIPMAPPING";
-	const std::string kHDR = "HDR";
 
 	m_metadata->Add(kMinFilter, static_cast<int>(ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
 	m_metadata->Add(kMagFilter, static_cast<int>(ETextureFilteringMode::LINEAR));
 	m_metadata->Add(kEnableMipmapping, true);
-	m_metadata->Add(kHDR, false);
 
 	const auto filteringModes = std::map<int, std::string>{
 		{static_cast<int>(ETextureFilteringMode::NEAREST), "NEAREST"},
@@ -320,15 +318,6 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 		},
 		[this, kEnableMipmapping](bool value) {
 			m_metadata->Set<bool>(kEnableMipmapping, value);
-		}
-	);
-
-	OvCore::Helpers::GUIDrawer::DrawBoolean(*m_settingsColumns, kHDR,
-		[this, kHDR]() {
-			return m_metadata->Get<bool>(kHDR);
-		},
-		[this, kHDR](bool value) {
-			m_metadata->Set<bool>(kHDR, value);
 		}
 	);
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
@@ -31,14 +31,12 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
-		* @param p_hdr
 		*/
 		static Texture* Create(
 			const std::string& p_filepath,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
-			bool p_generateMipmap,
-			bool p_hdr = false
+			bool p_generateMipmap
 		);
 
 		/**
@@ -58,7 +56,6 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
-		* @param p_hdr
 		*/
 		static Texture* CreateFromMemory(
 			uint8_t* p_data,
@@ -66,8 +63,7 @@ namespace OvRendering::Resources::Loaders
 			uint32_t p_height,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
-			bool p_generateMipmap,
-			bool p_hdr = false
+			bool p_generateMipmap
 		);
 
 		/**
@@ -77,15 +73,13 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
-		* @param p_hdr
 		*/
 		static void Reload(
 			Texture& p_texture,
 			const std::string& p_filePath,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
-			bool p_generateMipmap,
-			bool p_hdr
+			bool p_generateMipmap
 		);
 
 		/**

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
@@ -31,11 +31,18 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
+		* @param p_hdr
 		*/
-		static Texture* Create(const std::string& p_filepath, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap);
+		static Texture* Create(
+			const std::string& p_filepath,
+			OvRendering::Settings::ETextureFilteringMode p_minFilter,
+			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			bool p_generateMipmap,
+			bool p_hdr = false
+		);
 
 		/**
-		* Create a texture from a single pixel color
+		* Create a texture from a single SDR pixel color
 		* @param p_r
 		* @param p_g
 		* @param p_b
@@ -51,8 +58,17 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
+		* @param p_hdr
 		*/
-		static Texture* CreateFromMemory(uint8_t* p_data, uint32_t p_width, uint32_t p_height, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap);
+		static Texture* CreateFromMemory(
+			uint8_t* p_data,
+			uint32_t p_width,
+			uint32_t p_height,
+			OvRendering::Settings::ETextureFilteringMode p_minFilter,
+			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			bool p_generateMipmap,
+			bool p_hdr = false
+		);
 
 		/**
 		* Reload a texture from file
@@ -61,8 +77,16 @@ namespace OvRendering::Resources::Loaders
 		* @param p_minFilter
 		* @param p_magFilter
 		* @param p_generateMipmap
+		* @param p_hdr
 		*/
-		static void Reload(Texture& p_texture, const std::string& p_filePath, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap);
+		static void Reload(
+			Texture& p_texture,
+			const std::string& p_filePath,
+			OvRendering::Settings::ETextureFilteringMode p_minFilter,
+			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			bool p_generateMipmap,
+			bool p_hdr
+		);
 
 		/**
 		* Destroy a texture

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
@@ -6,36 +6,58 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 
-#include <stb_image/stb_image.h>
 #include <array>
+#include <format>
 #include <memory>
+#include <stb_image/stb_image.h>
 
-#include "OvRendering/Resources/Loaders/TextureLoader.h"
+#include <OvDebug/Logger.h>
+#include <OvRendering/Resources/Loaders/TextureLoader.h>
 #include <OvTools/Utils/PathParser.h>
 
 namespace
 {
 	struct Image
 	{
-		uint8_t* data;
-		int width;
-		int height;
-		int bpp;
+		int width = 0;
+		int height = 0;
+		int bpp = 0;
+		bool isHDR = false;
+		union
+		{
+			uint8_t* sdr;
+			float* hdr;
+			void* ptr;
+		} data;
 
-		Image(const std::string& p_filepath)
+		Image(const std::string& p_filepath, bool p_hdr)
 		{
 			stbi_set_flip_vertically_on_load(true);
-			data = stbi_load(p_filepath.c_str(), &width, &height, &bpp, 4);
+
+			if (p_hdr && stbi_is_hdr(p_filepath.c_str()))
+			{
+				isHDR = true;
+				data.hdr = stbi_loadf(p_filepath.c_str(), &width, &height, &bpp, 4);
+			}
+			else
+			{
+				if (p_hdr)
+				{
+					OVLOG_WARNING(std::format("Image at path \"{}\" doesn't support HDR, falling back to SDR.", p_filepath));
+				}
+
+				data.sdr = stbi_load(p_filepath.c_str(), &width, &height, &bpp, 4);
+			}
 		}
 
-		~Image()
+		virtual ~Image()
 		{
-			stbi_image_free(data);
+			stbi_image_free(data.ptr);
 		}
 
 		bool IsValid() const
 		{
-			return data;
+			return data.ptr;
 		}
 
 		operator bool() const
@@ -46,12 +68,13 @@ namespace
 
 	void PrepareTexture(
 		OvRendering::HAL::Texture& p_texture,
-		uint8_t* p_data,
+		void* p_data,
 		OvRendering::Settings::ETextureFilteringMode p_minFilter,
 		OvRendering::Settings::ETextureFilteringMode p_magFilter,
 		uint32_t p_width,
 		uint32_t p_height,
-		bool p_generateMipmap
+		bool p_generateMipmap,
+		bool p_hdr
 	)
 	{
 		using namespace OvRendering::Settings;
@@ -61,11 +84,11 @@ namespace
 			.height = p_height,
 			.minFilter = p_minFilter,
 			.magFilter = p_magFilter,
-			.internalFormat = EInternalFormat::RGBA8,
+			.internalFormat = p_hdr ? EInternalFormat::RGBA16F : EInternalFormat::RGBA8,
 			.useMipMaps = p_generateMipmap
 		});
 
-		p_texture.Upload(p_data, EFormat::RGBA, EPixelDataType::UNSIGNED_BYTE);
+		p_texture.Upload(p_data, EFormat::RGBA, p_hdr ? EPixelDataType::FLOAT : EPixelDataType::UNSIGNED_BYTE);
 
 		if (p_generateMipmap)
 		{
@@ -74,19 +97,30 @@ namespace
 	}
 }
 
-OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::Create(const std::string& p_filepath, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap)
+OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::Create(
+	const std::string& p_filepath,
+	OvRendering::Settings::ETextureFilteringMode p_minFilter,
+	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	bool p_generateMipmap,
+	bool p_hdr
+)
 {
-	if (Image image{ p_filepath })
+	if (Image image{ p_filepath, p_hdr })
 	{
 		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filepath));
-		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap);
+		PrepareTexture(*texture, image.data.ptr, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap, image.isHDR);
 		return new Texture{ p_filepath, std::move(texture) };
 	}
 
 	return nullptr;
 }
 
-OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::CreatePixel(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::CreatePixel(
+	uint8_t r,
+	uint8_t g,
+	uint8_t b,
+	uint8_t a
+)
 {
 	std::array<uint8_t, 4> colorData = { r, g, b, a };
 
@@ -98,19 +132,34 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 	);
 }
 
-OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::CreateFromMemory(uint8_t* p_data, uint32_t p_width, uint32_t p_height, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap)
+OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader::CreateFromMemory(
+	uint8_t* p_data,
+	uint32_t p_width,
+	uint32_t p_height,
+	OvRendering::Settings::ETextureFilteringMode p_minFilter,
+	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	bool p_generateMipmap,
+	bool p_hdr
+)
 {
 	auto texture = std::make_unique<HAL::Texture>("FromMemory");
-	PrepareTexture(*texture, p_data, p_minFilter, p_magFilter, p_width, p_height, p_generateMipmap);
+	PrepareTexture(*texture, p_data, p_minFilter, p_magFilter, p_width, p_height, p_generateMipmap, p_hdr);
 	return new Texture("", std::move(texture));
 }
 
-void OvRendering::Resources::Loaders::TextureLoader::Reload(Texture& p_texture, const std::string& p_filePath, OvRendering::Settings::ETextureFilteringMode p_minFilter, OvRendering::Settings::ETextureFilteringMode p_magFilter, bool p_generateMipmap)
+void OvRendering::Resources::Loaders::TextureLoader::Reload(
+	Texture& p_texture,
+	const std::string& p_filePath,
+	OvRendering::Settings::ETextureFilteringMode p_minFilter,
+	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	bool p_generateMipmap,
+	bool p_hdr
+)
 {
-	if (Image image{ p_filePath })
+	if (Image image{ p_filePath, p_hdr })
 	{
 		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filePath));
-		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap);
+		PrepareTexture(*texture, image.data.ptr, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap, image.isHDR);
 		p_texture.SetTexture(std::move(texture));
 	}
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
@@ -17,6 +17,10 @@
 
 namespace
 {
+	/**
+	* Simple wrapper for stb_image. Handles SDR and HDR image loading,
+	* and enforces RAII for the loaded data.
+	*/
 	struct Image
 	{
 		int width = 0;
@@ -36,20 +40,9 @@ namespace
 				static_cast<void*>(stbi_load(p_filepath.c_str(), &width, &height, &bpp, 4));
 		}
 
-		virtual ~Image()
-		{
-			stbi_image_free(data);
-		}
-
-		bool IsValid() const
-		{
-			return data;
-		}
-
-		operator bool() const
-		{
-			return IsValid();
-		}
+		virtual ~Image() { stbi_image_free(data); }
+		bool IsValid() const { return data; }
+		operator bool() const { return IsValid(); }
 	};
 
 	void PrepareTexture(

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.h
@@ -50,7 +50,7 @@ namespace OvTools::Filesystem
 		* @param p_key
 		*/
 		template<SupportedIniType T>
-		T Get(const std::string& p_key);
+		T Get(const std::string& p_key) const;
 
 		/**
 		* Return the value attached to the given key
@@ -59,7 +59,7 @@ namespace OvTools::Filesystem
 		* @param p_default
 		*/
 		template<SupportedIniType T>
-		T GetOrDefault(const std::string& p_key, T p_default);
+		T GetOrDefault(const std::string& p_key, T p_default) const;
 
 		/**
 		* Try to get the value attached to the given key
@@ -67,7 +67,7 @@ namespace OvTools::Filesystem
 		* @param p_outValue
 		*/
 		template<SupportedIniType T>
-		bool TryGet(const std::string& p_key, T& p_outValue);
+		bool TryGet(const std::string& p_key, T& p_outValue) const;
 
 		/**
 		* Set a new value to the given key (Not applied to the real file untill Rewrite() or Save() is called)

--- a/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
+++ b/Sources/Overload/OvTools/include/OvTools/Filesystem/IniFile.inl
@@ -13,39 +13,41 @@
 namespace OvTools::Filesystem
 {
 	template<SupportedIniType T>
-	inline T IniFile::Get(const std::string& p_key)
+	inline T IniFile::Get(const std::string& p_key) const
 	{
 		if (!IsKeyExisting(p_key))
 		{
 			return T{};
 		}
 
+		const auto value = m_data.at(p_key);
+
 		if constexpr (std::same_as<T, bool>)
 		{
-			return m_data[p_key] == "1" || m_data[p_key] == "T" || m_data[p_key] == "t" || m_data[p_key] == "True" || m_data[p_key] == "true";
+			return value == "1" || value == "T" || value == "t" || value == "True" || value == "true";
 		}
 		else if constexpr (std::same_as<T, std::string>)
 		{
-			return m_data[p_key];
+			return value;
 		}
 		else if constexpr (std::integral<T>)
 		{
-			return static_cast<T>(std::atoi(m_data[p_key].c_str()));
+			return static_cast<T>(std::atoi(value.c_str()));
 		}
 		else if constexpr (std::floating_point<T>)
 		{
-			return static_cast<T>(std::atof(m_data[p_key].c_str()));
+			return static_cast<T>(std::atof(value.c_str()));
 		}
 	}
 
 	template<SupportedIniType T>
-	inline T IniFile::GetOrDefault(const std::string& p_key, T p_default)
+	inline T IniFile::GetOrDefault(const std::string& p_key, T p_default) const
 	{
 		return IsKeyExisting(p_key) ? Get<T>(p_key) : p_default;
 	}
 
 	template<SupportedIniType T>
-	inline bool IniFile::TryGet(const std::string& p_key, T& p_outValue)
+	inline bool IniFile::TryGet(const std::string& p_key, T& p_outValue) const
 	{
 		if (IsKeyExisting(p_key))
 		{

--- a/Sources/Overload/OvTools/src/OvTools/Utils/PathParser.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Utils/PathParser.cpp
@@ -5,10 +5,8 @@
 */
 
 #include <algorithm>
-#include <array>
-#include <set>
 
-#include "OvTools/Utils/PathParser.h"
+#include <OvTools/Utils/PathParser.h>
 
 std::string OvTools::Utils::PathParser::MakeWindowsStyle(const std::string & p_path)
 {

--- a/Sources/Overload/OvTools/src/OvTools/Utils/PathParser.cpp
+++ b/Sources/Overload/OvTools/src/OvTools/Utils/PathParser.cpp
@@ -5,6 +5,8 @@
 */
 
 #include <algorithm>
+#include <array>
+#include <set>
 
 #include "OvTools/Utils/PathParser.h"
 
@@ -104,15 +106,15 @@ OvTools::Utils::PathParser::EFileType OvTools::Utils::PathParser::GetFileType(co
 	std::string ext = GetExtension(p_path);
 	std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
-	if (ext == "fbx" || ext == "obj")											return EFileType::MODEL;
-	else if (ext == "png" || ext == "jpeg" || ext == "jpg" || ext == "tga")		return EFileType::TEXTURE;
-	else if (ext == "ovfx")														return EFileType::SHADER;
-	else if (ext == "ovfxh")													return EFileType::SHADER_PART;
-	else if (ext == "ovmat")													return EFileType::MATERIAL;
-	else if (ext == "wav" || ext == "mp3" || ext == "ogg")						return EFileType::SOUND;
-	else if (ext == "ovscene")													return EFileType::SCENE;
-	else if (ext == "lua" || ext == "ovscript")									return EFileType::SCRIPT;
-	else if (ext == "ttf")														return EFileType::FONT;
+	if (ext == "fbx" || ext == "obj") return EFileType::MODEL;
+	else if (ext == "png" || ext == "jpeg" || ext == "jpg" || ext == "tga" || ext == "hdr") return EFileType::TEXTURE;
+	else if (ext == "ovfx") return EFileType::SHADER;
+	else if (ext == "ovfxh") return EFileType::SHADER_PART;
+	else if (ext == "ovmat") return EFileType::MATERIAL;
+	else if (ext == "wav" || ext == "mp3" || ext == "ogg") return EFileType::SOUND;
+	else if (ext == "ovscene") return EFileType::SCENE;
+	else if (ext == "lua" || ext == "ovscript") return EFileType::SCRIPT;
+	else if (ext == "ttf") return EFileType::FONT;
 
 	return EFileType::UNKNOWN;
 }


### PR DESCRIPTION
## Description
Added support for HDR textures:
- Automatically loads texture as HDR if the content is indeed HDR, otherwise load it as SDR
- `.hdr` files are now supported, and loaded with the internal format `RGBA16F`.

## Review Guidance
* Added some `const` qualifiers to `IniFile` so that it `Get` and `TryGet`, and `GetOrDefault` can be called using a `const IniFile`.
* Cleaned-up texture metadata `std::tuple` (made it into a proper `struct`)

## Screenshots

https://github.com/user-attachments/assets/5517d6aa-d812-408a-bea5-0a7bae75a7cd

_HDR on/off (the feature to toggle it is not present, this was just for debugging purposes)_