### PR TITLE
Updated default camera settings to more appropriate values

### DIFF
--- a/Sources/Overload/OvRendering/src/OvRendering/Entities/Camera.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Entities/Camera.cpp
@@ -11,11 +11,11 @@
 
 OvRendering::Entities::Camera::Camera(OvTools::Utils::OptRef<OvMaths::FTransform> p_transform) :
 	Entity{ p_transform },
-    m_projectionMode(Settings::EProjectionMode::PERSPECTIVE),
-	m_fov(45.0f),
-    m_size(5.0f),
+	m_projectionMode(Settings::EProjectionMode::PERSPECTIVE),
+	m_fov(60.0f),
+	m_size(5.0f),
 	m_near(0.1f),
-	m_far(100.f),
+	m_far(1000.f),
 	m_clearColor(0.f, 0.f, 0.f),
 	m_clearColorBuffer(true),
 	m_clearDepthBuffer(true),


### PR DESCRIPTION
## Description
* Updated default camera settings to more appropriate values:
  * FOV: 45 --> 60
  * Far: 100 --> 1000

**_For reference, Cargo uses a FOV of 55._**

## Screenshots
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/e6c87509-aaa1-4f15-b483-ae59b3eeb2f3) | ![image](https://github.com/user-attachments/assets/c229bc83-09e8-4757-a832-d9ff2566c040) |
_On the before pic, the skybox wouldn't show up since its size is 1000 units_
