### PR TITLE
Fixed the "Compile All Shaders" button

### DIFF
--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -237,7 +237,7 @@ namespace
 		{
 			if (!p_disableLogging && __LOGGING_SETTINGS.linkingErrors)
 			{
-				OVLOG_INFO(std::format(
+				OVLOG_ERROR(std::format(
 					"[Shader Linking] {}{}: {}",
 					p_shaderInputInfo.name,
 					FeatureSetToString(p_features),


### PR DESCRIPTION
## Description
The "Compile All Shaders" button was broken, and resulted in a bunch of errors being displayed. This was due to the `pathParserCallback`  not being provided.

This PR fixes that issue by using `ReloadResource` instead of `Recompile`, which internally calls `Recompile` and automatically provides the `pathParserCallback` to the `ShaderLoader`, as well as properly enabling shader compilation logging.

Also updated an `OVLOG_INFO` that was supposed to be an `OVLOG_ERROR` in the shader compilation code.

## Screenshot(s)
 

https://github.com/user-attachments/assets/18f13cb3-96c0-4bca-8d4b-bc796639ca83

