### PR TITLE
Disabled frustum culling in asset view

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
@@ -45,6 +45,7 @@ OvEditor::Panels::AssetView::AssetView
 
 	m_assetActor = &m_scene.CreateActor("Asset");
 	m_modelRenderer = &m_assetActor->AddComponent<OvCore::ECS::Components::CModelRenderer>();
+	m_modelRenderer->SetFrustumBehaviour(OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::DISABLED);
 	m_materialRenderer = &m_assetActor->AddComponent<OvCore::ECS::Components::CMaterialRenderer>();
 
 	m_cameraController.LockTargetActor(*m_assetActor);


### PR DESCRIPTION
## Description
The asset view shouldn't use any frustum culling, as the behaviour cannot be specialized (custom bounds). Also, the relevance of this feature for a single object is extremely low.

Additionally, some materials have undefined or variable bounds, so frustum culling will likely fail and cull the object.

## Screenshot(s)

### Before

https://github.com/user-attachments/assets/d7558a40-9212-44ca-8eaf-1bdd3d963079

_Frustum culling behaves like there is a model at the origin of the world_

### After


https://github.com/user-attachments/assets/a90ab630-4d77-42e8-b314-f05e6edfb748

_No frustum culling_


