### PR TITLE
Added support for custom picking pass

### DIFF
--- a/Resources/Editor/Shaders/PickingFallback.ovfx
+++ b/Resources/Editor/Shaders/PickingFallback.ovfx
@@ -1,0 +1,30 @@
+#shader vertex
+#version 450 core
+
+layout (location = 0) in vec3 geo_Pos;
+
+layout (std140) uniform EngineUBO
+{
+    mat4    ubo_Model;
+    mat4    ubo_View;
+    mat4    ubo_Projection;
+    vec3    ubo_ViewPos;
+    float   ubo_Time;
+};
+
+void main()
+{
+    gl_Position = ubo_Projection * ubo_View * ubo_Model * vec4(geo_Pos, 1.0);
+}
+
+#shader fragment
+#version 450 core
+
+uniform vec4 _PickingColor = vec4(1.0);
+
+out vec4 FRAGMENT_COLOR;
+
+void main()
+{
+    FRAGMENT_COLOR = _PickingColor;
+}

--- a/Sources/Overload/OvEditor/include/OvEditor/Rendering/PickingRenderPass.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Rendering/PickingRenderPass.h
@@ -66,7 +66,7 @@ namespace OvEditor::Rendering
 
 	private:
 		OvRendering::HAL::Framebuffer m_actorPickingFramebuffer;
-		OvCore::Resources::Material m_actorPickingMaterial;
+		OvCore::Resources::Material m_actorPickingFallbackMaterial;
 		OvCore::Resources::Material m_lightMaterial;
 		OvCore::Resources::Material m_gizmoPickingMaterial;
 	};

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
@@ -129,6 +129,7 @@ OvEditor::Core::EditorResources::EditorResources(const std::string& p_editorAsse
 		{"Grid", CreateShader(shadersFolder / "Grid.ovfx")},
 		{"Gizmo", CreateShader(shadersFolder / "Gizmo.ovfx")},
 		{"Billboard", CreateShader(shadersFolder / "Billboard.ovfx")},
+		{"PickingFallback", CreateShader(shadersFolder / "PickingFallback.ovfx")}
 	};
 
 	// Ensure that all resources have been loaded successfully


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Now possible to write a custom picking pass, especially useful when using custom vertex shaders, so that transformed vertices can be used for picking.

Added a `PickingFallback` shader in case no custom picking pass is found on a material.

## Limitations
We now need to add a custom outline pass!

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
N/A

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/91a095b3-c19a-4ac9-93cd-96e74da528c5

_Custom picking pass with a custom vertex shader. You can see the outline (indicating the mouse is over the object) shows up momentarily when the object moves under the cursor_
