### PR TITLE
Added support for custom outline pass

### DIFF
--- a/Resources/Editor/Shaders/OutlineFallback.ovfx
+++ b/Resources/Editor/Shaders/OutlineFallback.ovfx
@@ -1,0 +1,30 @@
+#shader vertex
+#version 450 core
+
+layout(location = 0) in vec3 geo_Pos;
+
+layout(std140) uniform EngineUBO
+{
+	mat4    ubo_Model;
+	mat4    ubo_View;
+	mat4    ubo_Projection;
+	vec3    ubo_ViewPos;
+	float   ubo_Time;
+};
+
+void main()
+{
+	gl_Position = ubo_Projection * ubo_View * ubo_Model * vec4(geo_Pos, 1.0);
+}
+
+#shader fragment
+#version 450 core
+
+uniform vec4 _OutlineColor = vec4(1.0);
+
+out vec4 FRAGMENT_COLOR;
+
+void main()
+{
+	FRAGMENT_COLOR = _OutlineColor;
+}

--- a/Sources/Overload/OvEditor/include/OvEditor/Rendering/OutlineRenderFeature.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Rendering/OutlineRenderFeature.h
@@ -46,9 +46,9 @@ namespace OvEditor::Rendering
 		void DrawOutlinePass(OvCore::ECS::Actor& p_actor, const OvMaths::FVector4& p_color, float p_thickness);
 		
 		void DrawActorToStencil(OvRendering::Data::PipelineState p_pso, OvCore::ECS::Actor& p_actor);
-		void DrawActorOutline(OvRendering::Data::PipelineState p_pso, OvCore::ECS::Actor& p_actor);
-		void DrawModelToStencil(OvRendering::Data::PipelineState p_pso, const OvMaths::FMatrix4& p_worldMatrix, OvRendering::Resources::Model& p_model);
-		void DrawModelOutline(OvRendering::Data::PipelineState p_pso, const OvMaths::FMatrix4& p_worldMatrix, OvRendering::Resources::Model& p_model);
+		void DrawActorOutline(OvRendering::Data::PipelineState p_pso, OvCore::ECS::Actor& p_actor, const OvMaths::FVector4& p_color);
+		void DrawModelToStencil(OvRendering::Data::PipelineState p_pso, const OvMaths::FMatrix4& p_worldMatrix, OvRendering::Resources::Model& p_model, OvTools::Utils::OptRef<const OvCore::ECS::Components::CMaterialRenderer::MaterialList> p_materials = std::nullopt);
+		void DrawModelOutline(OvRendering::Data::PipelineState p_pso, const OvMaths::FMatrix4& p_worldMatrix, OvRendering::Resources::Model& p_model, const OvMaths::FVector4& p_color, OvTools::Utils::OptRef<const OvCore::ECS::Components::CMaterialRenderer::MaterialList> p_materials = std::nullopt);
 
 	private:
 		OvCore::Resources::Material m_stencilFillMaterial;

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
@@ -129,7 +129,8 @@ OvEditor::Core::EditorResources::EditorResources(const std::string& p_editorAsse
 		{"Grid", CreateShader(shadersFolder / "Grid.ovfx")},
 		{"Gizmo", CreateShader(shadersFolder / "Gizmo.ovfx")},
 		{"Billboard", CreateShader(shadersFolder / "Billboard.ovfx")},
-		{"PickingFallback", CreateShader(shadersFolder / "PickingFallback.ovfx")}
+		{"PickingFallback", CreateShader(shadersFolder / "PickingFallback.ovfx")},
+		{"OutlineFallback", CreateShader(shadersFolder / "OutlineFallback.ovfx")}
 	};
 
 	// Ensure that all resources have been loaded successfully

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -29,7 +29,11 @@ namespace
 		auto bytes = reinterpret_cast<uint8_t*>(&actorID);
 		auto color = OvMaths::FVector4{ bytes[0] / 255.0f, bytes[1] / 255.0f, bytes[2] / 255.0f, 1.0f };
 
-		p_material.SetProperty(p_uniformName, color, true);
+		// Set the picking color property if it exists
+		if (p_material.GetProperty(p_uniformName))
+		{
+			p_material.SetProperty(p_uniformName, color, true);
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added support for custom outline pass.

If no outline pass is found on a material, the `OutlineFallback` shader will be used.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
N/A

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->


https://github.com/user-attachments/assets/ef71afff-9adc-4058-9392-e511859248a1


