### PR TITLE
Cleanup standard shaders

### DIFF
--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -12,6 +12,51 @@ vec2 TileAndOffsetTexCoords(vec2 texCoords, vec2 tiling, vec2 offset)
     return vec2(mod(texCoords.x * tiling.x, 1), mod(texCoords.y * tiling.y, 1)) + offset;
 }
 
+vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale)
+{
+    const vec3 viewDir = normalize(tangentViewPos - tangentFragPos);
+
+    // number of depth layers
+    const float minLayers = 8;
+    const float maxLayers = 64;
+    float numLayers = mix(maxLayers, minLayers, abs(dot(vec3(0.0, 0.0, 1.0), viewDir)));  
+    // calculate the size of each layer
+    float layerDepth = 1.0 / numLayers;
+    // depth of current layer
+    float currentLayerDepth = 0.0;
+    // the amount to shift the texture coordinates per layer (from vector P)
+    vec2 P = viewDir.xy / viewDir.z * heightScale; 
+    vec2 deltaTexCoords = P / numLayers;
+  
+    // get initial values
+    vec2  currentTexCoords     = texCoords;
+    float currentDepthMapValue = 1.0f - texture(heightMap, currentTexCoords).r;
+      
+    while(currentLayerDepth < currentDepthMapValue)
+    {
+        // shift texture coordinates along direction of P
+        currentTexCoords -= deltaTexCoords;
+        // get depthmap value at current texture coordinates
+        currentDepthMapValue = 1.0f - texture(heightMap, currentTexCoords).r;  
+        // get depth of next layer
+        currentLayerDepth += layerDepth;  
+    }
+    
+    // get texture coordinates before collision (reverse operations)
+    vec2 prevTexCoords = currentTexCoords + deltaTexCoords;
+
+    // get depth after and before collision for linear interpolation
+    float afterDepth  = currentDepthMapValue - currentLayerDepth;
+    float beforeDepth = 1.0f - texture(heightMap, prevTexCoords).r - currentLayerDepth + layerDepth;
+ 
+    // interpolation of texture coordinates
+    float weight = afterDepth / (afterDepth - beforeDepth);
+    vec2 finalTexCoords = prevTexCoords * weight + currentTexCoords * (1.0 - weight);
+
+    return finalTexCoords;
+}
+
+// [Deprecated] Kept for backward compatibility.
 vec2 ApplyParallaxMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale)
 {
     if (heightScale > 0)
@@ -24,6 +69,7 @@ vec2 ApplyParallaxMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewP
     return texCoords;
 }
 
+// [Deprecated] Kept for backward compatibility.
 bool IsMasked(sampler2D maskMap, vec2 texCoords)
 {
     return texture(maskMap, texCoords).r == 0.0;

--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -38,17 +38,21 @@ mat3 ConstructTBN(mat4 model, vec3 normal, vec3 tangent, vec3 bitangent)
     );
 }
 
+
+vec3 ComputeNormal(vec2 texCoords, vec3 normal, sampler2D normalMap, mat3 TBN)
+{
+    normal = texture(normalMap, texCoords).rgb;
+    normal = normalize(normal * 2.0 - 1.0);
+    normal = normalize(TBN * normal);
+    return normal;
+}
+
 vec3 ComputeNormal(bool enableNormalMapping, vec2 texCoords, vec3 normal, sampler2D normalMap, mat3 TBN)
 {
     if (enableNormalMapping)
     {
-        normal = texture(normalMap, texCoords).rgb;
-        normal = normalize(normal * 2.0 - 1.0);   
-        normal = normalize(TBN * normal);
-        return normal;
+        return ComputeNormal(texCoords, normal, normalMap, TBN);
     }
-    else
-    {
-        return normalize(normal);
-    }
+
+    return normalize(normal);
 }

--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -12,6 +12,8 @@ vec2 TileAndOffsetTexCoords(vec2 texCoords, vec2 tiling, vec2 offset)
     return vec2(mod(texCoords.x * tiling.x, 1), mod(texCoords.y * tiling.y, 1)) + offset;
 }
 
+// Expects a height map with values in the range [0, 1].
+// 1.0 means the height is at the maximum depth, 0.0 means the height is at the minimum depth.
 vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale)
 {
     const vec3 viewDir = normalize(tangentViewPos - tangentFragPos);
@@ -19,44 +21,44 @@ vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tan
     // number of depth layers
     const float minLayers = 8;
     const float maxLayers = 64;
-    float numLayers = mix(maxLayers, minLayers, abs(dot(vec3(0.0, 0.0, 1.0), viewDir)));  
+    const float numLayers = mix(maxLayers, minLayers, abs(dot(vec3(0.0, 0.0, 1.0), viewDir)));  
+
     // calculate the size of each layer
-    float layerDepth = 1.0 / numLayers;
-    // depth of current layer
-    float currentLayerDepth = 0.0;
+    const float layerDepth = 1.0 / numLayers;
     // the amount to shift the texture coordinates per layer (from vector P)
-    vec2 P = viewDir.xy / viewDir.z * heightScale; 
-    vec2 deltaTexCoords = P / numLayers;
+    const vec2 P = viewDir.xy / viewDir.z * heightScale; 
+    const vec2 deltaTexCoords = P / numLayers;
   
     // get initial values
-    vec2  currentTexCoords     = texCoords;
-    float currentDepthMapValue = 1.0f - texture(heightMap, currentTexCoords).r;
+    vec2 currentTexCoords = texCoords;
+    float currentDepthMapValue = 1.0 - texture(heightMap, currentTexCoords).r;
+    float currentLayerDepth = 0.0;
       
     while(currentLayerDepth < currentDepthMapValue)
     {
         // shift texture coordinates along direction of P
         currentTexCoords -= deltaTexCoords;
         // get depthmap value at current texture coordinates
-        currentDepthMapValue = 1.0f - texture(heightMap, currentTexCoords).r;  
+        currentDepthMapValue = 1.0 - texture(heightMap, currentTexCoords).r;
         // get depth of next layer
-        currentLayerDepth += layerDepth;  
+        currentLayerDepth += layerDepth;
     }
     
     // get texture coordinates before collision (reverse operations)
-    vec2 prevTexCoords = currentTexCoords + deltaTexCoords;
+    const vec2 prevTexCoords = currentTexCoords + deltaTexCoords;
 
     // get depth after and before collision for linear interpolation
-    float afterDepth  = currentDepthMapValue - currentLayerDepth;
-    float beforeDepth = 1.0f - texture(heightMap, prevTexCoords).r - currentLayerDepth + layerDepth;
+    const float afterDepth  = currentDepthMapValue - currentLayerDepth;
+    const float beforeDepth = 1.0 - texture(heightMap, prevTexCoords).r - currentLayerDepth + layerDepth;
  
     // interpolation of texture coordinates
-    float weight = afterDepth / (afterDepth - beforeDepth);
-    vec2 finalTexCoords = prevTexCoords * weight + currentTexCoords * (1.0 - weight);
+    const float weight = afterDepth / (afterDepth - beforeDepth);
+    const vec2 finalTexCoords = prevTexCoords * weight + currentTexCoords * (1.0 - weight);
 
     return finalTexCoords;
 }
 
-// [Deprecated] Kept for backward compatibility.
+// [Deprecated] Kept for backward compatibility. Prefer using `ApplyParallaxOcclusionMapping()` instead.
 vec2 ApplyParallaxMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale)
 {
     if (heightScale > 0)
@@ -93,6 +95,8 @@ vec3 ComputeNormal(vec2 texCoords, vec3 normal, sampler2D normalMap, mat3 TBN)
     return normal;
 }
 
+// [Deprecated] Kept for backward compatibility. Prefer using `ComputeNormal()` without the `enableNormalMapping` parameter,
+// and handle branching using preprocessor directives instead.
 vec3 ComputeNormal(bool enableNormalMapping, vec2 texCoords, vec3 normal, sampler2D normalMap, mat3 TBN)
 {
     if (enableNormalMapping)

--- a/Resources/Engine/Shaders/Lambert.ovfx
+++ b/Resources/Engine/Shaders/Lambert.ovfx
@@ -53,20 +53,29 @@ uniform sampler2D u_DiffuseMap;
 uniform vec2 u_TextureTiling = vec2(1.0, 1.0);
 uniform vec2 u_TextureOffset = vec2(0.0, 0.0);
 
+#if defined(SHADOW_PASS)
+uniform float u_ShadowClippingThreshold = 0.5;
+#endif
+
 out vec4 FRAGMENT_COLOR;
 
 void main()
 {
+    const vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
+    const vec4 diffuse = texture(u_DiffuseMap, texCoords) * u_Diffuse;
+
 #if defined(SHADOW_PASS)
-    // Empty fragment shader for shadow pass
+    if (diffuse.a < u_ShadowClippingThreshold)
+    {
+        discard;
+    }
 #else
-    vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
     
     const vec3 kLightPosition = vec3(-9000.0, 10000.0, 11000.0);
     const vec3 kLightDiffuse = vec3(1.0);
     const vec3 kLightAmbient = vec3(0.3);
-    const vec3 lambert = ComputeLambertLighting(fs_in.FragPos, fs_in.Normal, kLightPosition, kLightDiffuse, kLightAmbient);
+    const vec3 lambert = diffuse.rgb * ComputeLambertLighting(fs_in.FragPos, fs_in.Normal, kLightPosition, kLightDiffuse, kLightAmbient);
 
-    FRAGMENT_COLOR = texture(u_DiffuseMap, texCoords) * u_Diffuse * vec4(lambert, 1.0);
+    FRAGMENT_COLOR = vec4(lambert, diffuse.a);
 #endif
 }

--- a/Resources/Engine/Shaders/Lighting/BlinnPhong.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/BlinnPhong.ovfxh
@@ -81,10 +81,11 @@ vec3 ComputeAmbientSphereLight(mat4 light, vec3 fragPos, vec4 diffuseTexel)
     return IsPointInSphere(fragPos, lightPosition, radius) ? diffuseTexel.rgb * lightColor * intensity : vec3(0.0);
 }
 
-vec4 ComputeBlinnPhongLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 diffuse, vec3 specular, sampler2D diffuseMap, sampler2D specularMap, float shininess, sampler2D shadowMap, mat4 lightSpaceMatrix)
+// This version doesn't sample the diffuse texture, and expects the diffuse color to be passed in directly.
+// This is because other parts of the shader may have already sampled the diffuse texture, and we want to avoid double sampling.
+vec4 ComputeBlinnPhongLightingNoDiffuseSampling(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 diffuse, vec3 specular, sampler2D specularMap, float shininess, sampler2D shadowMap, mat4 lightSpaceMatrix)
 {
     vec3 viewDir = normalize(viewPos - fragPos);
-    vec4 diffuseTexel = texture(diffuseMap,  texCoords) * diffuse;
     vec4 specularTexel = texture(specularMap, texCoords) * vec4(specular, 1.0);
 
     vec3 lightAccumulation = vec3(0.0);
@@ -96,13 +97,31 @@ vec4 ComputeBlinnPhongLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 f
 
         switch(lightType)
         {
-            case 0: lightAccumulation += ComputePointLight(light, fragPos, diffuseTexel, specularTexel, normal, viewDir, shininess); break;
-            case 1: lightAccumulation += ComputeDirectionalLight(light, fragPos, diffuseTexel, specularTexel, normal, viewDir, shininess, shadowMap, lightSpaceMatrix); break;
-            case 2: lightAccumulation += ComputeSpotLight(light, fragPos, diffuseTexel, specularTexel, normal, viewDir, shininess); break;
-            case 3: lightAccumulation += ComputeAmbientBoxLight(light, fragPos, diffuseTexel); break;
-            case 4: lightAccumulation += ComputeAmbientSphereLight(light, fragPos, diffuseTexel); break;
+            case 0: lightAccumulation += ComputePointLight(light, fragPos, diffuse, specularTexel, normal, viewDir, shininess); break;
+            case 1: lightAccumulation += ComputeDirectionalLight(light, fragPos, diffuse, specularTexel, normal, viewDir, shininess, shadowMap, lightSpaceMatrix); break;
+            case 2: lightAccumulation += ComputeSpotLight(light, fragPos, diffuse, specularTexel, normal, viewDir, shininess); break;
+            case 3: lightAccumulation += ComputeAmbientBoxLight(light, fragPos, diffuse); break;
+            case 4: lightAccumulation += ComputeAmbientSphereLight(light, fragPos, diffuse); break;
         }
     }
 
-    return vec4(lightAccumulation, diffuseTexel.a);
+    return vec4(lightAccumulation, diffuse.a);
+}
+
+vec4 ComputeBlinnPhongLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 diffuse, vec3 specular, sampler2D diffuseMap, sampler2D specularMap, float shininess, sampler2D shadowMap, mat4 lightSpaceMatrix)
+{
+    vec4 diffuseTexel = texture(diffuseMap, texCoords) * diffuse;
+
+    return ComputeBlinnPhongLightingNoDiffuseSampling(
+        texCoords,
+        normal,
+        viewPos,
+        fragPos,
+        diffuseTexel,
+        specular,
+        specularMap,
+        shininess,
+        shadowMap,
+        lightSpaceMatrix
+    );
 }

--- a/Resources/Engine/Shaders/Lighting/PBR.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/PBR.ovfxh
@@ -63,10 +63,9 @@ vec3 ComputeAmbientSphereLight(mat4 light, vec3 fragPos)
     return IsPointInSphere(fragPos, lightPosition, radius) ? lightColor * intensity : vec3(0.0);
 }
 
-vec4 ComputePBRLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 inAlbedo, float inMetallic, float inRoughness, sampler2D albedoMap, sampler2D metallicMap, sampler2D roughnessMap, sampler2D aoMap, sampler2D shadowMap, mat4 lightSpaceMatrix)
+vec4 ComputePBRLightingNoAlbedoSampling(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 inAlbedo, float inMetallic, float inRoughness, sampler2D metallicMap, sampler2D roughnessMap, sampler2D aoMap, sampler2D shadowMap, mat4 lightSpaceMatrix)
 {
-    vec4 albedoRGBA = texture(albedoMap, texCoords) * inAlbedo;
-    vec3 albedo = pow(albedoRGBA.rgb, vec3(2.2));
+    vec3 albedo = pow(inAlbedo.rgb, vec3(2.2));
     float metallic = texture(metallicMap, texCoords).r * inMetallic;
     float roughness = texture(roughnessMap, texCoords).r * inRoughness;
     float ao = texture(aoMap, texCoords).r;
@@ -162,5 +161,24 @@ vec4 ComputePBRLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos,
     vec3 ambient = ambientSum * albedo * ao;
     vec3 color = ambient + Lo;
 	
-    return vec4(color, albedoRGBA.a);
+    return vec4(color, inAlbedo.a);
+}
+
+vec4 ComputePBRLighting(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 inAlbedo, float inMetallic, float inRoughness, sampler2D albedoMap, sampler2D metallicMap, sampler2D roughnessMap, sampler2D aoMap, sampler2D shadowMap, mat4 lightSpaceMatrix)
+{
+    vec4 albedoRGBA = texture(albedoMap, texCoords) * inAlbedo;
+    return ComputePBRLightingNoAlbedoSampling(
+        texCoords,
+        normal,
+        viewPos,
+        fragPos,
+        albedoRGBA,
+        inMetallic,
+        inRoughness,
+        metallicMap,
+        roughnessMap,
+        aoMap,
+        shadowMap,
+        lightSpaceMatrix
+    );
 }

--- a/Resources/Engine/Shaders/Lighting/PBR.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/PBR.ovfxh
@@ -63,6 +63,8 @@ vec3 ComputeAmbientSphereLight(mat4 light, vec3 fragPos)
     return IsPointInSphere(fragPos, lightPosition, radius) ? lightColor * intensity : vec3(0.0);
 }
 
+// This version doesn't sample the albedo texture, and expects the albedo color to be passed in directly.
+// This is because other parts of the shader may have already sampled the albedo texture, and we want to avoid double sampling.
 vec4 ComputePBRLightingNoAlbedoSampling(vec2 texCoords, vec3 normal, vec3 viewPos, vec3 fragPos, vec4 inAlbedo, float inMetallic, float inRoughness, sampler2D metallicMap, sampler2D roughnessMap, sampler2D aoMap, sampler2D shadowMap, mat4 lightSpaceMatrix)
 {
     vec3 albedo = pow(inAlbedo.rgb, vec3(2.2));

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -1,4 +1,7 @@
 #feature SHADOW_PASS
+#feature PARALLAX_MAPPING
+#feature ALPHA_CLIPPING
+#feature NORMAL_MAPPING
 
 #shader vertex
 #version 450 core
@@ -18,8 +21,10 @@ out VS_OUT
     vec2 TexCoords;
     vec3 Normal;
     mat3 TBN;
+#if defined(PARALLAX_MAPPING)
     flat vec3 TangentViewPos;
     vec3 TangentFragPos;
+#endif
 } vs_out;
 
 #if defined(SHADOW_PASS)
@@ -32,8 +37,11 @@ void main()
     vs_out.TexCoords = geo_TexCoords;
     vs_out.Normal = normalize(mat3(transpose(inverse(ubo_Model))) * geo_Normal);
     vs_out.TBN = ConstructTBN(ubo_Model, geo_Normal, geo_Tangent, geo_Bitangent);
+
+#if defined(PARALLAX_MAPPING)
     vs_out.TangentViewPos = transpose(vs_out.TBN) * ubo_ViewPos;
     vs_out.TangentFragPos = transpose(vs_out.TBN) * vs_out.FragPos;
+#endif
 
 #if defined(SHADOW_PASS)
     gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
@@ -54,22 +62,29 @@ in VS_OUT
     vec2 TexCoords;
     vec3 Normal;
     mat3 TBN;
+#if defined(PARALLAX_MAPPING)
     flat vec3 TangentViewPos;
     vec3 TangentFragPos;
+#endif
 } fs_in;
 
-uniform vec2 u_TextureTiling = vec2(1.0, 1.0);
-uniform vec2 u_TextureOffset = vec2(0.0, 0.0);
-uniform vec4 u_Diffuse = vec4(1.0, 1.0, 1.0, 1.0);
-uniform vec3 u_Specular = vec3(1.0, 1.0, 1.0);
-uniform float u_Shininess = 100.0;
-uniform float u_HeightScale = 0.0;
-uniform bool u_EnableNormalMapping = false;
 uniform sampler2D u_DiffuseMap;
 uniform sampler2D u_SpecularMap;
-uniform sampler2D u_NormalMap;
-uniform sampler2D u_HeightMap;
 uniform sampler2D u_MaskMap;
+uniform vec4 u_Diffuse = vec4(1.0, 1.0, 1.0, 1.0);
+uniform vec3 u_Specular = vec3(1.0, 1.0, 1.0);
+uniform vec2 u_TextureTiling = vec2(1.0, 1.0);
+uniform vec2 u_TextureOffset = vec2(0.0, 0.0);
+uniform float u_Shininess = 100.0;
+
+#if defined(PARALLAX_MAPPING)
+uniform sampler2D u_HeightMap;
+uniform float u_HeightScale = 0.0;
+#endif
+
+#if defined(NORMAL_MAPPING)
+uniform sampler2D u_NormalMap;
+#endif
 
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
@@ -78,23 +93,37 @@ out vec4 FRAGMENT_COLOR;
 
 void main()
 {
-#if defined(SHADOW_PASS)
-    // Empty fragment shader for shadow pass
-#else
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
-    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
 
-    if (!IsMasked(u_MaskMap, texCoords))
+#if defined(PARALLAX_MAPPING)
+    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+#endif
+
+    vec4 diffuse = texture(u_DiffuseMap, texCoords) * u_Diffuse;
+    diffuse.a *= texture(u_MaskMap, texCoords).r;
+
+#if defined(SHADOW_PASS)
+    if (diffuse.a < 0.5)
     {
-        vec3 normal = ComputeNormal(u_EnableNormalMapping, texCoords, fs_in.Normal, u_NormalMap, fs_in.TBN);
-        FRAGMENT_COLOR = ComputeBlinnPhongLighting(
+        discard;
+    }
+#else
+
+    if (diffuse.a > 0.0)
+    {
+#if defined(NORMAL_MAPPING)
+        const vec3 normal = ComputeNormal(texCoords, fs_in.Normal, u_NormalMap, fs_in.TBN);
+#else
+        const vec3 normal = normalize(fs_in.Normal);
+#endif
+
+        FRAGMENT_COLOR = ComputeBlinnPhongLightingNoDiffuseSampling(
             texCoords,
             normal,
             ubo_ViewPos,
             fs_in.FragPos,
-            u_Diffuse,
+            diffuse,
             u_Specular,
-            u_DiffuseMap,
             u_SpecularMap,
             u_Shininess,
             _ShadowMap,
@@ -103,7 +132,11 @@ void main()
     }
     else
     {
+#if defined(ALPHA_CLIPPING)
+        discard;
+#else
         FRAGMENT_COLOR = vec4(0.0);
+#endif
     }
 #endif
 }

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -90,6 +90,10 @@ uniform sampler2D u_NormalMap;
 uniform float u_AlphaClippingThreshold = 0.1;
 #endif
 
+#if defined(SHADOW_PASS)
+uniform float u_ShadowClippingThreshold = 0.5;
+#endif
+
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
 
@@ -107,7 +111,7 @@ void main()
     diffuse.a *= texture(u_MaskMap, texCoords).r;
 
 #if defined(SHADOW_PASS)
-    if (diffuse.a < 0.5)
+    if (diffuse.a < u_ShadowClippingThreshold)
     {
         discard;
     }

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -86,6 +86,10 @@ uniform float u_HeightScale = 0.0;
 uniform sampler2D u_NormalMap;
 #endif
 
+#if defined(ALPHA_CLIPPING)
+uniform float u_AlphaClippingThreshold = 0.1;
+#endif
+
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
 
@@ -108,6 +112,13 @@ void main()
         discard;
     }
 #else
+
+#if defined(ALPHA_CLIPPING)
+    if (diffuse.a < u_AlphaClippingThreshold)
+    {
+        discard;
+    }
+#endif
 
     if (diffuse.a > 0.0)
     {
@@ -132,11 +143,7 @@ void main()
     }
     else
     {
-#if defined(ALPHA_CLIPPING)
-        discard;
-#else
         FRAGMENT_COLOR = vec4(0.0);
-#endif
     }
 #endif
 }

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -79,7 +79,7 @@ uniform float u_Shininess = 100.0;
 
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
-uniform float u_HeightScale = 0.0;
+uniform float u_HeightScale = 0.05;
 #endif
 
 #if defined(NORMAL_MAPPING)
@@ -104,7 +104,11 @@ void main()
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
-    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0)
+    {
+        discard;
+    }
 #endif
 
     vec4 diffuse = texture(u_DiffuseMap, texCoords) * u_Diffuse;

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -79,6 +79,7 @@ uniform float u_Shininess = 100.0;
 
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
+uniform bool u_ParallaxClipEdges = false;
 uniform float u_HeightScale = 0.05;
 #endif
 
@@ -105,7 +106,7 @@ void main()
 
 #if defined(PARALLAX_MAPPING)
     texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
-    if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0)
+    if (u_ParallaxClipEdges && (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0))
     {
         discard;
     }

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -81,7 +81,7 @@ uniform sampler2D u_MaskMap;
 
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
-uniform float u_HeightScale = 0.0;
+uniform float u_HeightScale = 0.05;
 #endif
 
 #if defined(NORMAL_MAPPING)
@@ -106,7 +106,11 @@ void main()
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
-    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0)
+    {
+        discard;
+    }
 #endif
 
     vec4 albedo = texture(u_AlbedoMap, texCoords) * u_Albedo;

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -92,6 +92,10 @@ uniform sampler2D u_NormalMap;
 uniform float u_AlphaClippingThreshold = 0.1;
 #endif
 
+#if defined(SHADOW_PASS)
+uniform float u_ShadowClippingThreshold = 0.5;
+#endif
+
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
 
@@ -109,7 +113,7 @@ void main()
     albedo.a *= texture(u_MaskMap, texCoords).r;
 
 #if defined(SHADOW_PASS)
-    if (albedo.a < 0.5)
+    if (albedo.a < u_ShadowClippingThreshold)
     {
         discard;
     }

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -81,6 +81,7 @@ uniform sampler2D u_MaskMap;
 
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
+uniform bool u_ParallaxClipEdges = false;
 uniform float u_HeightScale = 0.05;
 #endif
 
@@ -107,7 +108,7 @@ void main()
 
 #if defined(PARALLAX_MAPPING)
     texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
-    if (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0)
+    if (u_ParallaxClipEdges && (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0))
     {
         discard;
     }

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -1,4 +1,7 @@
 #feature SHADOW_PASS
+#feature PARALLAX_MAPPING
+#feature ALPHA_CLIPPING
+#feature NORMAL_MAPPING
 
 #shader vertex
 #version 450 core
@@ -18,8 +21,10 @@ out VS_OUT
     vec2 TexCoords;
     vec3 Normal;
     mat3 TBN;
+#if defined(PARALLAX_MAPPING)
     flat vec3 TangentViewPos;
     vec3 TangentFragPos;
+#endif
 } vs_out;
 
 #if defined(SHADOW_PASS)
@@ -32,8 +37,11 @@ void main()
     vs_out.TexCoords = geo_TexCoords;
     vs_out.Normal = normalize(mat3(transpose(inverse(ubo_Model))) * geo_Normal);
     vs_out.TBN = ConstructTBN(ubo_Model, geo_Normal, geo_Tangent, geo_Bitangent);
+
+#if defined(PARALLAX_MAPPING)
     vs_out.TangentViewPos = transpose(vs_out.TBN) * ubo_ViewPos;
     vs_out.TangentFragPos = transpose(vs_out.TBN) * vs_out.FragPos;
+#endif
 
 #if defined(SHADOW_PASS)
     gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
@@ -54,24 +62,35 @@ in VS_OUT
     vec2 TexCoords;
     vec3 Normal;
     mat3 TBN;
+#if defined(PARALLAX_MAPPING)
     flat vec3 TangentViewPos;
     vec3 TangentFragPos;
+#endif
 } fs_in;
 
 uniform sampler2D u_AlbedoMap;
 uniform sampler2D u_MetallicMap;
 uniform sampler2D u_RoughnessMap;
 uniform sampler2D u_AmbientOcclusionMap;
-uniform sampler2D u_NormalMap;
 uniform vec4 u_Albedo = vec4(1.0);
 uniform vec2 u_TextureTiling = vec2(1.0, 1.0);
 uniform vec2 u_TextureOffset = vec2(0.0, 0.0);
-uniform bool u_EnableNormalMapping = false;
-uniform float u_HeightScale = 0.0;
 uniform float u_Metallic = 1.0;
 uniform float u_Roughness = 1.0;
-uniform sampler2D u_HeightMap;
 uniform sampler2D u_MaskMap;
+
+#if defined(PARALLAX_MAPPING)
+uniform sampler2D u_HeightMap;
+uniform float u_HeightScale = 0.0;
+#endif
+
+#if defined(NORMAL_MAPPING)
+uniform sampler2D u_NormalMap;
+#endif
+
+#if defined(ALPHA_CLIPPING)
+uniform float u_AlphaClippingThreshold = 0.1;
+#endif
 
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
@@ -80,16 +99,50 @@ out vec4 FRAGMENT_COLOR;
 
 void main()
 {
-#if defined(SHADOW_PASS)
-    // Empty fragment shader for shadow pass
-#else
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
-    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
 
-    if (!IsMasked(u_MaskMap, texCoords))
+#if defined(PARALLAX_MAPPING)
+    texCoords = ApplyParallaxMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+#endif
+
+    vec4 albedo = texture(u_AlbedoMap, texCoords) * u_Albedo;
+    albedo.a *= texture(u_MaskMap, texCoords).r;
+
+#if defined(SHADOW_PASS)
+    if (albedo.a < 0.5)
     {
-        vec3 normal = ComputeNormal(u_EnableNormalMapping, texCoords, fs_in.Normal, u_NormalMap, fs_in.TBN);
-        FRAGMENT_COLOR = ComputePBRLighting(texCoords, normal, ubo_ViewPos, fs_in.FragPos, u_Albedo, u_Metallic, u_Roughness, u_AlbedoMap, u_MetallicMap, u_RoughnessMap, u_AmbientOcclusionMap, _ShadowMap, _LightSpaceMatrix);
+        discard;
+    }
+#else
+
+#if defined(ALPHA_CLIPPING)
+    if (albedo.a < u_AlphaClippingThreshold)
+    {
+        discard;
+    }
+#endif
+
+    if (albedo.a > 0.0)
+    {
+#if defined(NORMAL_MAPPING)
+        const vec3 normal = ComputeNormal(texCoords, fs_in.Normal, u_NormalMap, fs_in.TBN);
+#else
+        const vec3 normal = normalize(fs_in.Normal);
+#endif
+        FRAGMENT_COLOR = ComputePBRLightingNoAlbedoSampling(
+            texCoords,
+            normal,
+            ubo_ViewPos,
+            fs_in.FragPos,
+            albedo,
+            u_Metallic,
+            u_Roughness,
+            u_MetallicMap,
+            u_RoughnessMap,
+            u_AmbientOcclusionMap,
+            _ShadowMap,
+            _LightSpaceMatrix
+        );
     }
     else
     {

--- a/Resources/Engine/Shaders/Unlit.ovfx
+++ b/Resources/Engine/Shaders/Unlit.ovfx
@@ -1,4 +1,5 @@
 #feature SHADOW_PASS
+#feature ALPHA_CLIPPING
 
 #shader vertex
 #version 450 core
@@ -43,10 +44,14 @@ in VS_OUT
     vec2 TexCoords;
 } fs_in;
 
-uniform vec4 u_Diffuse = vec4(1.0);
 uniform sampler2D u_DiffuseMap;
+uniform vec4 u_Diffuse = vec4(1.0);
 uniform vec2 u_TextureTiling = vec2(1.0);
 uniform vec2 u_TextureOffset = vec2(0.0);
+
+#if defined(ALPHA_CLIPPING)
+uniform float u_AlphaClippingThreshold = 0.1f;
+#endif
 
 out vec4 FRAGMENT_COLOR;
 
@@ -55,7 +60,14 @@ void main()
 #if defined(SHADOW_PASS)
     // Empty fragment shader for shadow pass
 #else
-    vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
-    FRAGMENT_COLOR = texture(u_DiffuseMap, texCoords) * u_Diffuse;
+    const vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
+    const vec4 diffuseColor = texture(u_DiffuseMap, texCoords) * u_Diffuse;
+#if defined(ALPHA_CLIPPING)
+    if (diffuseColor.a < u_AlphaClippingThreshold)
+    {
+        discard;
+    }
+#endif
+    FRAGMENT_COLOR = diffuseColor;
 #endif
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -33,6 +33,7 @@ namespace
 				std::nullopt;
 		};
 
+		if (auto value = as.operator()<bool>()) return *value;
 		if (auto value = as.operator()<int>()) return *value;
 		if (auto value = as.operator()<float>()) return *value;
 		if (auto value = as.operator()<FVector2>()) return *value;

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLShaderProgram.cpp
@@ -196,7 +196,7 @@ void OvRendering::HAL::GLShaderProgram::QueryUniforms()
 				switch (uniformType)
 				{
 					using enum Settings::EUniformType;
-					case BOOL: return GetUniform<int>(name);
+					case BOOL: return static_cast<bool>(GetUniform<int>(name));
 					case INT: return GetUniform<int>(name);
 					case FLOAT: return GetUniform<float>(name);
 					case FLOAT_VEC2: return GetUniform<OvMaths::FVector2>(name);

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -98,32 +98,31 @@ void OvRendering::Resources::Parsers::AssimpParser::ProcessMesh(void* p_transfor
 	for (uint32_t i = 0; i < p_mesh->mNumVertices; ++i)
 	{
 		const aiVector3D position = meshTransformation * p_mesh->mVertices[i];
-		const aiVector3D normal = meshTransformation * (p_mesh->mNormals ? p_mesh->mNormals[i] : aiVector3D(0.0f, 0.0f, 0.0f));
 		const aiVector3D texCoords = p_mesh->mTextureCoords[0] ? p_mesh->mTextureCoords[0][i] : aiVector3D(0.0f, 0.0f, 0.0f);
+		const aiVector3D normal = meshTransformation * (p_mesh->mNormals ? p_mesh->mNormals[i] : aiVector3D(0.0f, 0.0f, 0.0f));
 		const aiVector3D tangent = meshTransformation * (p_mesh->mTangents ? p_mesh->mTangents[i] : aiVector3D(0.0f, 0.0f, 0.0f));
-		// Multiply by -1 so that bitangent are left-handed?
-		// Not sure why it works, but it does (had to do that for parallax mapping).
-		const aiVector3D bitangent = meshTransformation * (p_mesh->mBitangents ? (p_mesh->mBitangents[i].SymMul(aiVector3D{ -1.0f })) : aiVector3D(0.0f, 0.0f, 0.0f));
+		const aiVector3D bitangent = meshTransformation * (p_mesh->mBitangents ? p_mesh->mBitangents[i] : aiVector3D(0.0f, 0.0f, 0.0f));
 
-		p_outVertices.push_back
-		(
-			{
-				position.x,
-				position.y,
-				position.z,
-				texCoords.x,
-				texCoords.y,
-				normal.x,
-				normal.y,
-				normal.z,
-				tangent.x,
-				tangent.y,
-				tangent.z,
-				bitangent.x,
-				bitangent.y,
-				bitangent.z
-			}
-		);
+		p_outVertices.push_back({
+			position.x,
+			position.y,
+			position.z,
+			texCoords.x,
+			texCoords.y,
+			normal.x,
+			normal.y,
+			normal.z,
+			tangent.x,
+			tangent.y,
+			tangent.z,
+			// Assimp calculates the tangent space vectors in a right-handed system.
+			// But our shader code expects a left-handed system.
+			// Multiplying the bitangent by -1 will convert it to a left-handed system.
+			// Learn OpenGL also uses a left-handed tangent space for normal mapping and parallax mapping.
+			-bitangent.x,
+			-bitangent.y,
+			-bitangent.z
+		});
 	}
 
 	for (uint32_t faceID = 0; faceID < p_mesh->mNumFaces; ++faceID)

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Parsers/AssimpParser.cpp
@@ -97,11 +97,13 @@ void OvRendering::Resources::Parsers::AssimpParser::ProcessMesh(void* p_transfor
 
 	for (uint32_t i = 0; i < p_mesh->mNumVertices; ++i)
 	{
-		aiVector3D position		= meshTransformation * p_mesh->mVertices[i];
-		aiVector3D normal		= meshTransformation * (p_mesh->mNormals ? p_mesh->mNormals[i] : aiVector3D(0.0f, 0.0f, 0.0f));
-		aiVector3D texCoords	= p_mesh->mTextureCoords[0] ? p_mesh->mTextureCoords[0][i] : aiVector3D(0.0f, 0.0f, 0.0f);
-		aiVector3D tangent		= p_mesh->mTangents ? meshTransformation * p_mesh->mTangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
-		aiVector3D bitangent	= p_mesh->mBitangents ? meshTransformation * p_mesh->mBitangents[i] : aiVector3D(0.0f, 0.0f, 0.0f);
+		const aiVector3D position = meshTransformation * p_mesh->mVertices[i];
+		const aiVector3D normal = meshTransformation * (p_mesh->mNormals ? p_mesh->mNormals[i] : aiVector3D(0.0f, 0.0f, 0.0f));
+		const aiVector3D texCoords = p_mesh->mTextureCoords[0] ? p_mesh->mTextureCoords[0][i] : aiVector3D(0.0f, 0.0f, 0.0f);
+		const aiVector3D tangent = meshTransformation * (p_mesh->mTangents ? p_mesh->mTangents[i] : aiVector3D(0.0f, 0.0f, 0.0f));
+		// Multiply by -1 so that bitangent are left-handed?
+		// Not sure why it works, but it does (had to do that for parallax mapping).
+		const aiVector3D bitangent = meshTransformation * (p_mesh->mBitangents ? (p_mesh->mBitangents[i].SymMul(aiVector3D{ -1.0f })) : aiVector3D(0.0f, 0.0f, 0.0f));
 
 		p_outVertices.push_back
 		(

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -23,7 +23,7 @@ size_t OvRendering::Resources::Shader::FeatureSetHash::operator()(const FeatureS
 
 	for (const auto& feature : fs)
 	{
-		hash ^= std::hash<std::string>{}(feature)+0x9e3779b9 + (hash << 6) + (hash >> 2);
+		hash ^= std::hash<std::string>{}(feature);
 	}
 
 	return hash;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Cleaned up standard shaders (Lambert, Standard, StandardPBR, Unlit)
  * Moved runtime branches to proper features (using the variant system)
* Fixed feature set not supporting permutations
* Fixed parallax mapping implementation
  * Bitangent had to be inverted (`* -1.0`)  to be left-handed instead of right-handed
* Fixed normal mapping (bitangent was inverted too)

## To-Do
- [x] ~Fix TBN needs to be right-handed for normal mapping, but left-handed for parallax~ both needed to be left-handed

## Breaking Changes
* `u_EnableNormalMapping` (used for runtime branching) has been removed in favor of the `NORMAL_MAPPING` feature (compile-time). Projects using this feature will need to be updated to use the `NORMAL_MAPPING` feature instead

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->


https://github.com/user-attachments/assets/2b9026f9-ec5b-46f5-8797-4c3a3c257b1b

_Parallax mapping finally working properly_

