### PR TITLE
Added atmospheric scattering

### DIFF
--- a/Resources/Engine/Materials/Atmosphere.ovmat
+++ b/Resources/Engine/Materials/Atmosphere.ovmat
@@ -1,5 +1,5 @@
 <root>
-    <shader>:Shaders\Skysphere.ovfx</shader>
+    <shader>:Shaders\Atmosphere.ovfx</shader>
     <settings>
         <blendable>false</blendable>
         <backface_culling>false</backface_culling>
@@ -11,36 +11,25 @@
         <receive_shadows>false</receive_shadows>
         <user_interface>false</user_interface>
         <gpu_instances>1</gpu_instances>
-        <draw_order>100</draw_order>
+        <draw_order>10</draw_order>
     </settings>
     <uniforms>
         <uniform>
-            <name>u_Diffuse</name>
-            <value>
-                <x>1</x>
-                <y>1</y>
-                <z>1</z>
-                <w>1</w>
-            </value>
+            <name>u_MiePreferredScatteringDirection</name>
+            <value>0.75800002</value>
         </uniform>
         <uniform>
-            <name>u_DiffuseMap</name>
-            <value>:Textures\PureSky.hdr</value>
+            <name>u_SunIntensity</name>
+            <value>22</value>
         </uniform>
         <uniform>
-            <name>u_TextureOffset</name>
+            <name>u_SunPosition</name>
             <value>
                 <x>0</x>
-                <y>0</y>
-            </value>
-        </uniform>
-        <uniform>
-            <name>u_TextureTiling</name>
-            <value>
-                <x>1</x>
-                <y>1</y>
+                <y>0.1</y>
+                <z>-1</z>
             </value>
         </uniform>
     </uniforms>
-    <features></features>
+    <features>DYNAMIC_SUN_POSITION</features>
 </root>

--- a/Resources/Engine/Shaders/Atmosphere.ovfx
+++ b/Resources/Engine/Shaders/Atmosphere.ovfx
@@ -1,0 +1,225 @@
+#feature OUTLINE_PASS
+#feature PICKING_PASS
+#feature DYNAMIC_SUN_POSITION
+
+#shader vertex
+#version 450 core
+
+#include ":Shaders/Common/Buffers/EngineUBO.ovfxh"
+#include ":Shaders/Common/Utils.ovfxh"
+#include ":Shaders/Common/Buffers/LightsSSBO.ovfxh"
+
+layout (location = 0) in vec3 geo_Pos;
+layout (location = 1) in vec2 geo_TexCoords;
+
+out VS_OUT
+{
+    vec3 FragPos;
+    flat vec3 SunPosition;
+} vs_out;
+
+uniform vec3 u_SunPosition = vec3(0.0, 0.1, -1.0); // Default sun position
+
+// Calculate the sun position based on the first directional light in the scene
+vec3 calculateSunPositionFromDirectionalLight()
+{
+    for (int i = 0; i < ssbo_Lights.length(); ++i)
+    {
+        const mat4 light = ssbo_Lights[i];
+        const int lightType = int(light[3][0]);
+
+        if (lightType == 1)
+        {
+            vec3 lightDirection = -light[1].xyz;
+            return normalize(lightDirection);
+        }
+    }
+
+    // If no directional light is found, use the sun position uniform
+    return u_SunPosition;
+}
+
+void main()
+{
+    vs_out.FragPos = geo_Pos;
+
+#if defined(DYNAMIC_SUN_POSITION)
+    vs_out.SunPosition = calculateSunPositionFromDirectionalLight();
+#else
+    vs_out.SunPosition = u_SunPosition;
+#endif
+
+    gl_Position = ubo_Projection * ubo_View * vec4(ubo_ViewPos + vs_out.FragPos, 1.0);
+}
+
+#shader fragment
+#version 450 core
+
+#include ":Shaders/Common/Buffers/EngineUBO.ovfxh"
+#include ":Shaders/Common/Utils.ovfxh"
+
+in VS_OUT
+{
+    vec3 FragPos;
+    flat vec3 SunPosition;
+} fs_in;
+
+#if defined(PICKING_PASS)
+uniform vec4 _PickingColor;
+#endif
+
+#if defined(OUTLINE_PASS)
+uniform vec4 _OutlineColor;
+#endif
+
+uniform float u_SunIntensity = 22.0; // Sun intensity
+uniform float u_MiePreferredScatteringDirection = 0.758; // Mie preferred scattering direction
+
+const vec3 kRayOrigin = vec3(0.0, 6372e3, 0.0); // Ray origin
+const float kPlanetRadius = 6371e3; // Radius of the planet in meters
+const float kAtmosphereRadius = 6471e3; // Radius of the atmosphere in meters
+const vec3 kRayleighScattering = vec3(5.5e-6, 13.0e-6, 22.4e-6); // Rayleigh scattering coefficient
+const float kMieScattering = 21e-6; // Mie scattering coefficient
+const float kRayleighScaleHeight = 8e3; // Rayleigh scale height
+const float kMieScaleHeight = 1.2e3; // Mie scale height
+
+out vec4 FRAGMENT_COLOR;
+
+// [ATMOSHPERIC SCATTERING] Section Start
+// From https://github.com/wwwtyro/glsl-atmosphere/blob/master/index.glsl
+#define PI 3.141592
+#define iSteps 16
+#define jSteps 8
+
+vec2 rsi(vec3 r0, vec3 rd, float sr) {
+    // ray-sphere intersection that assumes
+    // the sphere is centered at the origin.
+    // No intersection when result.x > result.y
+    float a = dot(rd, rd);
+    float b = 2.0 * dot(rd, r0);
+    float c = dot(r0, r0) - (sr * sr);
+    float d = (b*b) - 4.0*a*c;
+    if (d < 0.0) return vec2(1e5,-1e5);
+    return vec2(
+        (-b - sqrt(d))/(2.0*a),
+        (-b + sqrt(d))/(2.0*a)
+    );
+}
+
+vec3 atmosphere(vec3 r, vec3 r0, vec3 pSun, float iSun, float rPlanet, float rAtmos, vec3 kRlh, float kMie, float shRlh, float shMie, float g) {
+    // Normalize the sun and view directions.
+    pSun = normalize(pSun);
+    r = normalize(r);
+
+    // Calculate the step size of the primary ray.
+    vec2 p = rsi(r0, r, rAtmos);
+    if (p.x > p.y) return vec3(0,0,0);
+    p.y = min(p.y, rsi(r0, r, rPlanet).x);
+    float iStepSize = (p.y - p.x) / float(iSteps);
+
+    // Initialize the primary ray time.
+    float iTime = 0.0;
+
+    // Initialize accumulators for Rayleigh and Mie scattering.
+    vec3 totalRlh = vec3(0,0,0);
+    vec3 totalMie = vec3(0,0,0);
+
+    // Initialize optical depth accumulators for the primary ray.
+    float iOdRlh = 0.0;
+    float iOdMie = 0.0;
+
+    // Calculate the Rayleigh and Mie phases.
+    float mu = dot(r, pSun);
+    float mumu = mu * mu;
+    float gg = g * g;
+    float pRlh = 3.0 / (16.0 * PI) * (1.0 + mumu);
+    float pMie = 3.0 / (8.0 * PI) * ((1.0 - gg) * (mumu + 1.0)) / (pow(1.0 + gg - 2.0 * mu * g, 1.5) * (2.0 + gg));
+
+    // Sample the primary ray.
+    for (int i = 0; i < iSteps; i++) {
+
+        // Calculate the primary ray sample position.
+        vec3 iPos = r0 + r * (iTime + iStepSize * 0.5);
+
+        // Calculate the height of the sample.
+        float iHeight = length(iPos) - rPlanet;
+
+        // Calculate the optical depth of the Rayleigh and Mie scattering for this step.
+        float odStepRlh = exp(-iHeight / shRlh) * iStepSize;
+        float odStepMie = exp(-iHeight / shMie) * iStepSize;
+
+        // Accumulate optical depth.
+        iOdRlh += odStepRlh;
+        iOdMie += odStepMie;
+
+        // Calculate the step size of the secondary ray.
+        float jStepSize = rsi(iPos, pSun, rAtmos).y / float(jSteps);
+
+        // Initialize the secondary ray time.
+        float jTime = 0.0;
+
+        // Initialize optical depth accumulators for the secondary ray.
+        float jOdRlh = 0.0;
+        float jOdMie = 0.0;
+
+        // Sample the secondary ray.
+        for (int j = 0; j < jSteps; j++) {
+
+            // Calculate the secondary ray sample position.
+            vec3 jPos = iPos + pSun * (jTime + jStepSize * 0.5);
+
+            // Calculate the height of the sample.
+            float jHeight = length(jPos) - rPlanet;
+
+            // Accumulate the optical depth.
+            jOdRlh += exp(-jHeight / shRlh) * jStepSize;
+            jOdMie += exp(-jHeight / shMie) * jStepSize;
+
+            // Increment the secondary ray time.
+            jTime += jStepSize;
+        }
+
+        // Calculate attenuation.
+        vec3 attn = exp(-(kMie * (iOdMie + jOdMie) + kRlh * (iOdRlh + jOdRlh)));
+
+        // Accumulate scattering.
+        totalRlh += odStepRlh * attn;
+        totalMie += odStepMie * attn;
+
+        // Increment the primary ray time.
+        iTime += iStepSize;
+
+    }
+
+    // Calculate and return the final color.
+    return iSun * (pRlh * kRlh * totalRlh + pMie * kMie * totalMie);
+}
+// [ATMOSHPERIC SCATTERING] Section End
+
+void main()
+{
+#if defined(PICKING_PASS)
+    // The skysphere cannot be picked.
+    discard;
+#elif defined(OUTLINE_PASS)
+    // The skysphere cannot be outlined.
+    discard;
+#else
+
+    vec3 color = atmosphere(
+        normalize(fs_in.FragPos),           // normalized ray direction
+        kRayOrigin,                         // ray origin
+        fs_in.SunPosition,                  // position of the sun
+        u_SunIntensity,                     // intensity of the sun
+        kPlanetRadius,                      // radius of the planet in meters
+        kAtmosphereRadius,                  // radius of the atmosphere in meters
+        kRayleighScattering,                // Rayleigh scattering coefficient
+        kMieScattering,                     // Mie scattering coefficient
+        kRayleighScaleHeight,               // Rayleigh scale height
+        kMieScaleHeight,                    // Mie scale height
+        u_MiePreferredScatteringDirection   // Mie preferred scattering direction
+    );
+    
+    FRAGMENT_COLOR = vec4(color, 1.0);
+#endif
+}

--- a/Resources/Engine/Shaders/Skysphere.ovfx
+++ b/Resources/Engine/Shaders/Skysphere.ovfx
@@ -18,10 +18,9 @@ out VS_OUT
 
 void main()
 {
-    vs_out.FragPos = ubo_ViewPos + geo_Pos * 1000.0f;
+    vs_out.FragPos = geo_Pos;
     vs_out.TexCoords = geo_TexCoords;
-
-    gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
+    gl_Position = ubo_Projection * ubo_View * vec4(ubo_ViewPos + vs_out.FragPos, 1.0);
 }
 
 #shader fragment

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/SceneRenderer.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/SceneRenderer.h
@@ -28,9 +28,23 @@ namespace OvCore::Rendering
 	class SceneRenderer : public OvRendering::Core::CompositeRenderer
 	{
 	public:
-		using OpaqueDrawables = std::multimap<float, OvRendering::Entities::Drawable, std::less<float>>;
-		using TransparentDrawables = std::multimap<float, OvRendering::Entities::Drawable, std::greater<float>>;
-		using UIDrawables = std::multimap<float, OvRendering::Entities::Drawable, std::greater<float>>;
+		struct DrawOrder
+		{
+			int order;
+			float distance;
+
+			/**
+			* Determines the order of the drawables.
+			* Current order is: order -> distance
+			* @param p_other
+			*/
+			bool operator<(const DrawOrder& p_other) const;
+			bool operator>(const DrawOrder& p_other) const;
+		};
+
+		using OpaqueDrawables = std::multimap<DrawOrder, OvRendering::Entities::Drawable, std::less<DrawOrder>>;
+		using TransparentDrawables = std::multimap<DrawOrder, OvRendering::Entities::Drawable, std::greater<DrawOrder>>;
+		using UIDrawables = std::multimap<DrawOrder, OvRendering::Entities::Drawable, std::greater<DrawOrder>>;
 
 		struct AllDrawables
 		{

--- a/Sources/Overload/OvCore/include/OvCore/SceneSystem/Scene.h
+++ b/Sources/Overload/OvCore/include/OvCore/SceneSystem/Scene.h
@@ -66,6 +66,11 @@ namespace OvCore::SceneSystem
 		void AddDefaultSkysphere();
 
 		/**
+		* Add default atmosphere to the scene
+		*/
+		void AddDefaultAtmosphere();
+
+		/**
 		* Play the scene
 		*/
 		void Play();

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/SceneRenderer.cpp
@@ -21,6 +21,16 @@
 #include <OvRendering/HAL/Profiling.h>
 #include <OvRendering/Resources/Loaders/ShaderLoader.h>
 
+bool OvCore::Rendering::SceneRenderer::DrawOrder::operator<(const DrawOrder& p_other) const
+{
+	return order < p_other.order || (order == p_other.order && distance < p_other.distance);
+}
+
+bool OvCore::Rendering::SceneRenderer::DrawOrder::operator>(const DrawOrder& p_other) const
+{
+	return p_other.operator <(*this);
+}
+
 struct SceneRenderPassDescriptor
 {
 	OvCore::Rendering::SceneRenderer::AllDrawables drawables;
@@ -303,17 +313,26 @@ OvCore::Rendering::SceneRenderer::AllDrawables OvCore::Rendering::SceneRenderer:
 
 								if (material->IsUserInterface())
 								{
-									ui.emplace(distanceToActor, drawable);
+									ui.emplace(DrawOrder{
+										.order = material->GetDrawOrder(),
+										.distance = distanceToActor
+									}, drawable);
 								}
 								else
 								{
 									if (material->IsBlendable())
 									{
-										transparents.emplace(distanceToActor, drawable);
+										transparents.emplace(DrawOrder{
+											.order = material->GetDrawOrder(),
+											.distance = distanceToActor
+										}, drawable);
 									}
 									else
 									{
-										opaques.emplace(distanceToActor, drawable);
+										opaques.emplace(DrawOrder{
+											.order = material->GetDrawOrder(),
+											.distance = distanceToActor
+										}, drawable);
 									}
 								}
 							}

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -30,6 +30,7 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 	Serializer::SerializeBoolean(p_doc, settingsNode, "receive_shadows", m_receiveShadows);
 	Serializer::SerializeBoolean(p_doc, settingsNode, "user_interface", m_userInterface);
 	Serializer::SerializeInt(p_doc, settingsNode, "gpu_instances", m_gpuInstances);
+	Serializer::SerializeInt(p_doc, settingsNode, "draw_order", m_drawOrder);
 
 	// Create "Uniforms" (Every uniform will be attached to "Uniforms")
 	tinyxml2::XMLNode* uniformsNode = p_doc.NewElement("uniforms");
@@ -114,6 +115,7 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 		Serializer::DeserializeBoolean(p_doc, settingsNode, "receive_shadows", m_receiveShadows);
 		Serializer::DeserializeBoolean(p_doc, settingsNode, "user_interface", m_userInterface);
 		Serializer::DeserializeInt(p_doc, settingsNode, "gpu_instances", m_gpuInstances);
+		Serializer::DeserializeInt(p_doc, settingsNode, "draw_order", m_drawOrder);
 	}
 
 	/* We get the shader with Deserialize method */

--- a/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/SceneSystem/Scene.cpp
@@ -79,6 +79,27 @@ void OvCore::SceneSystem::Scene::AddDefaultSkysphere()
 	}
 }
 
+void OvCore::SceneSystem::Scene::AddDefaultAtmosphere()
+{
+	auto& atmosphere = CreateActor("Atmoshpere");
+	auto& materialRenderer = atmosphere.AddComponent<ECS::Components::CMaterialRenderer>();
+	auto& modelRenderer = atmosphere.AddComponent<ECS::Components::CModelRenderer>();
+	modelRenderer.SetFrustumBehaviour(ECS::Components::CModelRenderer::EFrustumBehaviour::DISABLED);
+
+	auto atmosphereMaterial = Global::ServiceLocator::Get<ResourceManagement::MaterialManager>().GetResource(":Materials\\Atmosphere.ovmat");
+	auto sphereModel = Global::ServiceLocator::Get<ResourceManagement::ModelManager>().GetResource(":Models\\Sphere.fbx");
+
+	if (atmosphereMaterial)
+	{
+		materialRenderer.SetMaterialAtIndex(0, *atmosphereMaterial);
+	}
+
+	if (sphereModel)
+	{
+		modelRenderer.SetModel(sphereModel);
+	}
+}
+
 void OvCore::SceneSystem::Scene::Play()
 {
 	m_isPlaying = true;

--- a/Sources/Overload/OvCore/src/OvCore/SceneSystem/SceneManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/SceneSystem/SceneManager.cpp
@@ -56,7 +56,7 @@ void OvCore::SceneSystem::SceneManager::LoadDefaultScene()
 	m_currentScene->AddDefaultCamera();
 	m_currentScene->AddDefaultLights();
 	m_currentScene->AddDefaultPostProcessStack();
-	m_currentScene->AddDefaultSkysphere();
+	m_currentScene->AddDefaultAtmosphere();
 	SceneLoadEvent.Invoke();
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetBrowser.cpp
@@ -355,6 +355,7 @@ namespace
 				auto& createUnlitShaderMenu = createShaderMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Unlit template");
 				auto& createLambertShaderMenu = createShaderMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Lambert template");
 				auto& createSkysphereShaderMenu = createShaderMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Skysphere template");
+				auto& createAtmosphereShaderMenu = createShaderMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Atmosphere template");
 
 				auto& createEmptyMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Empty");
 				auto& createStandardMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Standard");
@@ -362,6 +363,7 @@ namespace
 				auto& createUnlitMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Unlit");
 				auto& createLambertMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Lambert");
 				auto& createSkysphereMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Skysphere");
+				auto& createAtmosphereMaterialMenu = createMaterialMenu.CreateWidget<OvUI::Widgets::Menu::MenuList>("Atmosphere");
 
 				auto& createFolder = createFolderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createScene = createSceneMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
@@ -372,6 +374,7 @@ namespace
 				auto& createUnlitMaterial = createUnlitMaterialMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createLambertMaterial = createLambertMaterialMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createSkysphereMaterial = createSkysphereMaterialMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
+				auto& createAtmosphereMaterial = createAtmosphereMaterialMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 
 				auto& createEmptyShader = createEmptyShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createPartialShader = createPartialShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
@@ -380,6 +383,7 @@ namespace
 				auto& createUnlitShader = createUnlitShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createLambertShader = createLambertShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 				auto& createSkysphereShader = createSkysphereShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
+				auto& createAtmosphereShader = createAtmosphereShaderMenu.CreateWidget<OvUI::Widgets::InputFields::InputText>("");
 
 				createFolderMenu.ClickedEvent += [&createFolder] { createFolder.content = ""; };
 				createSceneMenu.ClickedEvent += [&createScene] { createScene.content = ""; };
@@ -388,6 +392,7 @@ namespace
 				createUnlitShaderMenu.ClickedEvent += [&createUnlitShader] { createUnlitShader.content = ""; };
 				createLambertShaderMenu.ClickedEvent += [&createLambertShader] { createLambertShader.content = ""; };
 				createSkysphereShaderMenu.ClickedEvent += [&createSkysphereShader] { createSkysphereShader.content = ""; };
+				createAtmosphereShaderMenu.ClickedEvent += [&createAtmosphereShader] { createAtmosphereShader.content = ""; };
 				createEmptyMaterialMenu.ClickedEvent += [&createEmptyMaterial] { createEmptyMaterial.content = ""; };
 				createEmptyShaderMenu.ClickedEvent += [&createEmptyShader] { createEmptyShader.content = ""; };
 				createPartialShaderMenu.ClickedEvent += [&createPartialShader] { createPartialShader.content = ""; };
@@ -396,6 +401,7 @@ namespace
 				createUnlitMaterialMenu.ClickedEvent += [&createUnlitMaterial] { createUnlitMaterial.content = ""; };
 				createLambertMaterialMenu.ClickedEvent += [&createLambertMaterial] { createLambertMaterial.content = ""; };
 				createSkysphereMaterialMenu.ClickedEvent += [&createSkysphereMaterial] { createSkysphereMaterial.content = ""; };
+				createAtmosphereMaterialMenu.ClickedEvent += [&createAtmosphereMaterial] { createAtmosphereMaterial.content = ""; };
 
 				createFolder.EnterPressedEvent += [this](std::string newFolderName)
 				{
@@ -460,6 +466,7 @@ namespace
 				CreateNewShaderCallback(createUnlitShader, "Unlit");
 				CreateNewShaderCallback(createLambertShader, "Lambert");
 				CreateNewShaderCallback(createSkysphereShader, "Skysphere");
+				CreateNewShaderCallback(createAtmosphereShader, "Atmosphere");
 
 				CreateNewMaterialCallback(createEmptyMaterial);
 				CreateNewMaterialCallback(createStandardMaterial, "Standard");
@@ -469,8 +476,21 @@ namespace
 				CreateNewMaterialCallback(createSkysphereMaterial, "Skysphere", [](OvCore::Resources::Material& material) {
 					// A default skysphere material should have backface culling disabled
 					// And frontface culling enabled (renders the inside of the sphere).
+					material.SetDrawOrder(100);
+					material.SetDepthTest(false);
+					material.SetDepthWriting(false);
 					material.SetBackfaceCulling(false);
 					material.SetFrontfaceCulling(true);
+				});
+				CreateNewMaterialCallback(createAtmosphereMaterial, "Atmosphere", [](OvCore::Resources::Material& material) {
+					// A default atmosphere material should have backface culling disabled
+					// And frontface culling enabled (renders the inside of the cube).
+					material.SetDrawOrder(10);
+					material.SetDepthTest(false);
+					material.SetDepthWriting(false);
+					material.SetBackfaceCulling(false);
+					material.SetFrontfaceCulling(true);
+					material.AddFeature("DYNAMIC_SUN_POSITION");
 				});
 
 				BrowserItemContextualMenu::CreateList();

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetView.cpp
@@ -38,7 +38,7 @@ OvEditor::Panels::AssetView::AssetView
 
 	m_scene.AddDefaultLights();
 	m_scene.AddDefaultPostProcessStack();
-	m_scene.AddDefaultSkysphere();
+	m_scene.AddDefaultAtmosphere();
 
 	m_assetActor = &m_scene.CreateActor("Asset");
 	m_modelRenderer = &m_assetActor->AddComponent<OvCore::ECS::Components::CModelRenderer>();

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -416,6 +416,7 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialSettingsContent()
 	GUIDrawer::DrawBoolean(*m_materialSettingsColumns, "Shadow Receiving", std::bind(&OvCore::Resources::Material::IsShadowReceiver, m_target), std::bind(&OvCore::Resources::Material::SetReceiveShadows, m_target, std::placeholders::_1));
 	GUIDrawer::DrawBoolean(*m_materialSettingsColumns, "User Interface", std::bind(&OvCore::Resources::Material::IsUserInterface, m_target), std::bind(&OvCore::Resources::Material::SetUserInterface, m_target, std::placeholders::_1));
 	GUIDrawer::DrawScalar<int>(*m_materialSettingsColumns, "GPU Instances", std::bind(&OvCore::Resources::Material::GetGPUInstances, m_target), std::bind(&OvCore::Resources::Material::SetGPUInstances, m_target, std::placeholders::_1), 1.0f, 0, 100000);
+	GUIDrawer::DrawScalar<int>(*m_materialSettingsColumns, "Draw Order", std::bind(&OvCore::Resources::Material::GetDrawOrder, m_target), std::bind(&OvCore::Resources::Material::SetDrawOrder, m_target, std::placeholders::_1), 1.0f, 0, 100000);
 }
 
 void OvEditor::Panels::MaterialEditor::GenerateMaterialFeaturesContent()

--- a/Sources/Overload/OvEditor/src/OvEditor/Utils/ActorCreationMenu.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Utils/ActorCreationMenu.cpp
@@ -66,6 +66,32 @@ namespace
 		EDITOR_EXEC(SelectActor(instance));
 	}
 
+	void CreateAtmosphere(OvCore::ECS::Actor* p_parent)
+	{
+		auto& instance = EDITOR_EXEC(CreateEmptyActor(false, p_parent));
+
+		auto& materialRenderer = instance.AddComponent<OvCore::ECS::Components::CMaterialRenderer>();
+		auto& modelRenderer = instance.AddComponent<OvCore::ECS::Components::CModelRenderer>();
+		modelRenderer.SetFrustumBehaviour(OvCore::ECS::Components::CModelRenderer::EFrustumBehaviour::DISABLED);
+
+		auto atmosphereMaterial = EDITOR_CONTEXT(materialManager).GetResource(":Materials\\Atmosphere.ovmat");
+		auto sphereModel = EDITOR_CONTEXT(modelManager).GetResource(":Models\\Sphere.fbx");
+
+		if (atmosphereMaterial)
+		{
+			materialRenderer.SetMaterialAtIndex(0, *atmosphereMaterial);
+		}
+
+		if (sphereModel)
+		{
+			modelRenderer.SetModel(sphereModel);
+		}
+
+		instance.SetName("Atmosphere");
+
+		EDITOR_EXEC(SelectActor(instance));
+	}
+
 	template<class T>
 	std::function<void()> ActorWithComponentCreationHandler(OvCore::ECS::Actor* p_parent, std::optional<std::function<void()>> p_onItemClicked)
 	{
@@ -80,6 +106,11 @@ namespace
 	std::function<void()> CreateSkysphereHandler(OvCore::ECS::Actor* p_parent, std::optional<std::function<void()>> p_onItemClicked)
 	{
 		return Combine(std::bind(CreateSkysphere, p_parent), p_onItemClicked);
+	}
+
+	std::function<void()> CreateAtmosphereHandler(OvCore::ECS::Actor* p_parent, std::optional<std::function<void()>> p_onItemClicked)
+	{
+		return Combine(std::bind(CreateAtmosphere, p_parent), p_onItemClicked);
 	}
 }
 
@@ -119,4 +150,5 @@ void OvEditor::Utils::ActorCreationMenu::GenerateActorCreationMenu(OvUI::Widgets
 	others.CreateWidget<MenuItem>("Camera").ClickedEvent += ActorWithComponentCreationHandler<CCamera>(p_parent, p_onItemClicked);
 	others.CreateWidget<MenuItem>("Post Process Stack").ClickedEvent += ActorWithComponentCreationHandler<CPostProcessStack>(p_parent, p_onItemClicked);
 	others.CreateWidget<MenuItem>("Skysphere").ClickedEvent += CreateSkysphereHandler(p_parent, p_onItemClicked);
+	others.CreateWidget<MenuItem>("Atmosphere").ClickedEvent += CreateAtmosphereHandler(p_parent, p_onItemClicked);
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -110,6 +110,12 @@ namespace OvRendering::Data
 		bool IsValid() const;
 
 		/**
+		* Sets the draw order of the material
+		* @param p_order
+		*/
+		void SetDrawOrder(int p_order);
+
+		/**
 		* Defines if the material is blendable
 		* @param p_blendable
 		*/
@@ -169,6 +175,11 @@ namespace OvRendering::Data
 		* @param p_instances
 		*/
 		void SetGPUInstances(int p_instances);
+
+		/**
+		* Returns the draw order of the material
+		*/
+		int GetDrawOrder() const;
 
 		/**
 		* Returns true if the material is blendable
@@ -275,5 +286,6 @@ namespace OvRendering::Data
 		bool m_receiveShadows = false;
 
 		int m_gpuInstances = 1;
+		int m_drawOrder = 1000;
 	};
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -260,6 +260,11 @@ bool OvRendering::Data::Material::IsValid() const
 	return HasShader();
 }
 
+void OvRendering::Data::Material::SetDrawOrder(int p_order)
+{
+	m_drawOrder = p_order;
+}
+
 void OvRendering::Data::Material::SetBlendable(bool p_transparent)
 {
 	m_blendable = p_transparent;
@@ -309,6 +314,11 @@ void OvRendering::Data::Material::SetReceiveShadows(bool p_receiveShadows)
 void OvRendering::Data::Material::SetGPUInstances(int p_instances)
 {
 	m_gpuInstances = p_instances;
+}
+
+int OvRendering::Data::Material::GetDrawOrder() const
+{
+	return m_drawOrder;
 }
 
 bool OvRendering::Data::Material::IsBlendable() const


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Implemented atmospheric scattering, with dynamic sun position calculated from directional light
* Changed default scene to use atmosphere instead of skysphere
* Updated asset browser to create atmosphere shaders and materials
* Updated actor creation menu to create atmosphere actors
* Updated material system to change draw order within a pass (default draw order: 1000)
* Updated skysphere material to be drawn early (draw order 100)
* Set atmosphere draw order to 10

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->


https://github.com/user-attachments/assets/1f1c5b4b-0605-45a2-818b-18cf73a686ce

_New flow in the editor_

https://github.com/user-attachments/assets/9226f00e-ab38-4262-83b7-1ded3abf6d89

_Atmoshperic scattering calculated based on directional light forward_

