### PR TITLE
Updated material editor to only show relevant shader settings

### DIFF
--- a/Resources/Engine/Materials/Default.ovmat
+++ b/Resources/Engine/Materials/Default.ovmat
@@ -11,15 +11,9 @@
         <receive_shadows>true</receive_shadows>
         <user_interface>false</user_interface>
         <gpu_instances>1</gpu_instances>
+        <draw_order>1000</draw_order>
     </settings>
     <uniforms>
-        <uniform>
-            <name>_LightSpaceMatrix</name>
-        </uniform>
-        <uniform>
-            <name>_ShadowMap</name>
-            <value>?</value>
-        </uniform>
         <uniform>
             <name>u_Albedo</name>
             <value>
@@ -34,20 +28,8 @@
             <value>?</value>
         </uniform>
         <uniform>
-            <name>u_AlphaClippingThreshold</name>
-            <value>0.1</value>
-        </uniform>
-        <uniform>
             <name>u_AmbientOcclusionMap</name>
             <value>?</value>
-        </uniform>
-        <uniform>
-            <name>u_HeightMap</name>
-            <value>?</value>
-        </uniform>
-        <uniform>
-            <name>u_HeightScale</name>
-            <value>0.050000001</value>
         </uniform>
         <uniform>
             <name>u_MaskMap</name>
@@ -62,24 +44,12 @@
             <value>?</value>
         </uniform>
         <uniform>
-            <name>u_NormalMap</name>
-            <value>?</value>
-        </uniform>
-        <uniform>
-            <name>u_ParallaxClipEdges</name>
-            <value>0</value>
-        </uniform>
-        <uniform>
             <name>u_Roughness</name>
             <value>0.5</value>
         </uniform>
         <uniform>
             <name>u_RoughnessMap</name>
             <value>?</value>
-        </uniform>
-        <uniform>
-            <name>u_ShadowClippingThreshold</name>
-            <value>0.5</value>
         </uniform>
         <uniform>
             <name>u_TextureOffset</name>

--- a/Resources/Engine/Shaders/Atmosphere.ovfx
+++ b/Resources/Engine/Shaders/Atmosphere.ovfx
@@ -6,11 +6,9 @@
 #version 450 core
 
 #include ":Shaders/Common/Buffers/EngineUBO.ovfxh"
-#include ":Shaders/Common/Utils.ovfxh"
 #include ":Shaders/Common/Buffers/LightsSSBO.ovfxh"
 
 layout (location = 0) in vec3 geo_Pos;
-layout (location = 1) in vec2 geo_TexCoords;
 
 out VS_OUT
 {
@@ -56,7 +54,6 @@ void main()
 #version 450 core
 
 #include ":Shaders/Common/Buffers/EngineUBO.ovfxh"
-#include ":Shaders/Common/Utils.ovfxh"
 
 in VS_OUT
 {

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
@@ -42,8 +42,17 @@ void OvCore::Rendering::ShadowRenderFeature::OnBeforeDraw(OvRendering::Data::Pip
 					if (light.type == OvRendering::Settings::ELightType::DIRECTIONAL)
 					{
 						const auto shadowTex = light.GetShadowBuffer().GetAttachment<OvRendering::HAL::Texture>(OvRendering::Settings::EFramebufferAttachment::DEPTH);
-						material.SetProperty("_ShadowMap", &shadowTex.value(), true); // Single use material property
-						material.SetProperty("_LightSpaceMatrix", light.GetLightSpaceMatrix(), true);
+
+						if (!material.TrySetProperty("_ShadowMap", &shadowTex.value(), true))
+						{
+							OVLOG_WARNING("ShadowRenderFeature: Material does not have a _ShadowMap property");
+						}
+
+						if (!material.TrySetProperty("_LightSpaceMatrix", light.GetLightSpaceMatrix(), true))
+						{
+							OVLOG_WARNING("ShadowRenderFeature: Material does not have a _LightSpaceMatrix property");
+						}
+
 						++lightIndex;
 					}
 				}

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -36,8 +36,28 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 	tinyxml2::XMLNode* uniformsNode = p_doc.NewElement("uniforms");
 	p_node->InsertEndChild(uniformsNode);
 
+	const auto program = GetProgram();
+
+	// If the material has no valid program for the current feature set, we skip serialization of properties.
+	if (!program)
+	{
+		return;
+	}
+
 	for (const auto& [name, prop] : m_properties)
 	{
+		// Skip serialization of this property if the current program isn't using its associated uniform
+		if (!program->GetUniformInfo(name))
+		{
+			continue;
+		}
+
+		// Skip serialization of this property if it is marked as single-use
+		if (prop.singleUse)
+		{
+			continue;
+		}
+
 		auto& value = prop.value;
 		tinyxml2::XMLNode* uniform = p_doc.NewElement("uniform");
 		uniformsNode->InsertEndChild(uniform);

--- a/Sources/Overload/OvEditor/include/OvEditor/Panels/MaterialEditor.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Panels/MaterialEditor.h
@@ -71,30 +71,30 @@ namespace OvEditor::Panels
 		void CreateMaterialSelector();
 		void CreateShaderSelector();
 		void CreateMaterialSettings();
-		void CreateShaderSettings();
-		void CreateFeatureSettings();
+		void CreateMaterialFeatures();
+		void CreateMaterialProperties();
 
-		void GenerateShaderSettingsContent();
 		void GenerateMaterialSettingsContent();
 		void GenerateMaterialFeaturesContent();
+		void GenerateMaterialPropertiesContent();
 
 	private:
-		OvCore::Resources::Material* m_target		= nullptr;
-		OvRendering::Resources::Shader* m_shader	= nullptr;
+		OvCore::Resources::Material* m_target = nullptr;
+		OvRendering::Resources::Shader* m_shader = nullptr;
 
-		OvUI::Widgets::Texts::Text* m_targetMaterialText	= nullptr;
-		OvUI::Widgets::Texts::Text* m_shaderText			= nullptr;
+		OvUI::Widgets::Texts::Text* m_targetMaterialText = nullptr;
+		OvUI::Widgets::Texts::Text* m_shaderText = nullptr;
 
 		OvTools::Eventing::Event<> m_materialDroppedEvent;
 		OvTools::Eventing::Event<> m_shaderDroppedEvent;
 
-		OvUI::Widgets::Layout::Group* m_settings			= nullptr;
-		OvUI::Widgets::Layout::Group* m_materialSettings	= nullptr;
-		OvUI::Widgets::Layout::Group* m_shaderSettings = nullptr;
-		OvUI::Widgets::Layout::Group* m_featureSettings = nullptr;
+		OvUI::Widgets::Layout::Group* m_settings = nullptr;
+		OvUI::Widgets::Layout::Group* m_materialSettings = nullptr;
+		OvUI::Widgets::Layout::Group* m_materialFeatures = nullptr;
+		OvUI::Widgets::Layout::Group* m_materialProperties = nullptr;
 
-		OvUI::Widgets::Layout::Columns<2>* m_shaderSettingsColumns = nullptr;
 		OvUI::Widgets::Layout::Columns<2>* m_materialSettingsColumns = nullptr;
-		OvUI::Widgets::Layout::Columns<2>* m_featureSettingsColumns = nullptr;
+		OvUI::Widgets::Layout::Columns<2>* m_materialFeaturesColumns = nullptr;
+		OvUI::Widgets::Layout::Columns<2>* m_materialPropertiesColumns = nullptr;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MaterialEditor.cpp
@@ -4,21 +4,23 @@
 * @licence: MIT
 */
 
-#include "OvEditor/Panels/MaterialEditor.h"
-#include "OvEditor/Panels/AssetView.h"
 
-#include "OvEditor/Core/EditorActions.h"
 
-#include <OvCore/Resources/Loaders/MaterialLoader.h>
 #include <OvCore/Helpers/GUIDrawer.h>
-#include <OvUI/Widgets/Layout/Columns.h>
-#include <OvUI/Widgets/Layout/GroupCollapsable.h>
-#include <OvUI/Widgets/Visual/Separator.h>
-#include <OvUI/Widgets/Texts/TextColored.h>
+#include <OvCore/Resources/Loaders/MaterialLoader.h>
+
+#include <OvEditor/Core/EditorActions.h>
+#include <OvEditor/Panels/AssetView.h>
+#include <OvEditor/Panels/MaterialEditor.h>
+
 #include <OvUI/Widgets/Buttons/Button.h>
 #include <OvUI/Widgets/Buttons/ButtonSmall.h>
-#include <OvUI/Widgets/Selection/ComboBox.h>
+#include <OvUI/Widgets/Layout/Columns.h>
+#include <OvUI/Widgets/Layout/GroupCollapsable.h>
 #include <OvUI/Widgets/Selection/ColorEdit.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
+#include <OvUI/Widgets/Texts/TextColored.h>
+#include <OvUI/Widgets/Visual/Separator.h>
 
 using namespace OvUI::Panels;
 using namespace OvUI::Widgets;
@@ -136,8 +138,7 @@ namespace
 	}
 }
 
-OvEditor::Panels::MaterialEditor::MaterialEditor
-(
+OvEditor::Panels::MaterialEditor::MaterialEditor(
 	const std::string& p_title,
 	bool p_opened,
 	const OvUI::Settings::PanelWindowSettings& p_windowSettings
@@ -150,11 +151,11 @@ OvEditor::Panels::MaterialEditor::MaterialEditor
 	m_settings = &CreateWidget<Layout::Group>();
 	CreateShaderSelector();
 	CreateMaterialSettings();
-	CreateShaderSettings();
-	CreateFeatureSettings();
+	CreateMaterialFeatures();
+	CreateMaterialProperties();
 
 	m_settings->enabled = false;
-	m_shaderSettings->enabled = false;
+	m_materialProperties->enabled = false;
 
 	m_materialDroppedEvent += std::bind(&MaterialEditor::OnMaterialDropped, this);
 	m_shaderDroppedEvent += std::bind(&MaterialEditor::OnShaderDropped, this);
@@ -190,7 +191,9 @@ void OvEditor::Panels::MaterialEditor::Preview()
 	auto& assetView = EDITOR_PANEL(Panels::AssetView, "Asset View");
 
 	if (m_target)
+	{
 		assetView.SetResource(m_target);
+	}
 
 	assetView.Open();
 }
@@ -219,28 +222,32 @@ void OvEditor::Panels::MaterialEditor::OnMaterialDropped()
 		m_materialSettingsColumns->RemoveAllWidgets();
 	}
 
-	m_shaderSettings->enabled = false;
-	m_shaderSettingsColumns->RemoveAllWidgets();
+	m_materialProperties->enabled = false;
+	m_materialPropertiesColumns->RemoveAllWidgets();
 
 	if (m_target && m_target->GetShader())
+	{
 		OnShaderDropped();
+	}
 }
 
 void OvEditor::Panels::MaterialEditor::OnShaderDropped()
 {
-	m_shaderSettings->enabled = m_shader; // Enable m_shaderSettings group if the shader of the target material is non-null
+	m_materialProperties->enabled = m_shader; // Enable m_shaderSettings group if the shader of the target material is non-null
 
 	if (m_shader != m_target->GetShader())
-		m_target->SetShader(m_shader);
-
-	if (m_shaderSettings->enabled)
 	{
-		GenerateShaderSettingsContent();
+		m_target->SetShader(m_shader);
+	}
+
+	if (m_materialProperties->enabled)
+	{
+		GenerateMaterialPropertiesContent();
 		GenerateMaterialFeaturesContent();
 	}
 	else
 	{
-		m_shaderSettingsColumns->RemoveAllWidgets();
+		m_materialPropertiesColumns->RemoveAllWidgets();
 	}
 }
 
@@ -248,20 +255,22 @@ void OvEditor::Panels::MaterialEditor::CreateHeaderButtons()
 {
 	auto& saveButton = CreateWidget<Buttons::Button>("Save to file");
 	saveButton.idleBackgroundColor = { 0.0f, 0.5f, 0.0f };
-	saveButton.ClickedEvent += [this]
-	{
+	saveButton.ClickedEvent += [this] {
 		if (m_target)
+		{
 			OvCore::Resources::Loaders::MaterialLoader::Save(*m_target, EDITOR_EXEC(GetRealPath(m_target->path)));
+		}
 	};
 
 	saveButton.lineBreak = false;
 
 	auto& reloadButton = CreateWidget<Buttons::Button>("Reload from file");
 	reloadButton.idleBackgroundColor = { 0.7f, 0.5f, 0.0f };
-	reloadButton.ClickedEvent += [this]
-	{
+	reloadButton.ClickedEvent += [this] {
 		if (m_target)
+		{
 			OvCore::Resources::Loaders::MaterialLoader::Reload(*m_target, EDITOR_EXEC(GetRealPath(m_target->path)));
+		}
 
 		OnMaterialDropped();
 	};
@@ -294,121 +303,23 @@ void OvEditor::Panels::MaterialEditor::CreateShaderSelector()
 
 void OvEditor::Panels::MaterialEditor::CreateMaterialSettings()
 {
-	m_materialSettings = &m_settings->CreateWidget<Layout::GroupCollapsable>("Material Settings");
+	m_materialSettings = &m_settings->CreateWidget<Layout::GroupCollapsable>("Settings");
 	m_materialSettingsColumns = &m_materialSettings->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
 	m_materialSettingsColumns->widths[0] = 150;
 }
 
-void OvEditor::Panels::MaterialEditor::CreateShaderSettings()
+void OvEditor::Panels::MaterialEditor::CreateMaterialFeatures()
 {
-	m_shaderSettings = &m_settings->CreateWidget<Layout::GroupCollapsable>("Shader Settings");
-	m_shaderSettingsColumns = &m_shaderSettings->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
-	m_shaderSettingsColumns->widths[0] = 150;
+	m_materialFeatures = &m_settings->CreateWidget<Layout::GroupCollapsable>("Features");
+	m_materialFeaturesColumns = &m_materialFeatures->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
+	m_materialFeaturesColumns->widths[0] = 150;
 }
 
-void OvEditor::Panels::MaterialEditor::CreateFeatureSettings()
+void OvEditor::Panels::MaterialEditor::CreateMaterialProperties()
 {
-	m_featureSettings = &m_settings->CreateWidget<Layout::GroupCollapsable>("Feature Settings");
-	m_featureSettingsColumns = &m_featureSettings->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
-	m_featureSettingsColumns->widths[0] = 150;
-}
-
-void OvEditor::Panels::MaterialEditor::GenerateShaderSettingsContent()
-{
-	using namespace OvRendering::Settings;
-	using namespace OvRendering::Resources;
-
-	m_shaderSettingsColumns->RemoveAllWidgets(); // Ensure that the m_shaderSettingsColumns is empty
-
-	std::multimap<
-		int,
-		std::pair<
-			std::string,
-			std::reference_wrapper<OvRendering::Data::MaterialPropertyType>
-		>
-	> sortedProperties;
-
-	auto typeIndexVisitor = [&](auto& arg) -> uint32_t {
-		using T = std::decay_t<decltype(arg)>;
-
-		if constexpr (std::is_same_v<T, Texture*>) return 0;
-		else if constexpr (std::is_same_v<T, OvMaths::FVector4>) return 1;
-		else if constexpr (std::is_same_v<T, OvMaths::FVector3>) return 2;
-		else if constexpr (std::is_same_v<T, OvMaths::FVector2>) return 3;
-		else if constexpr (std::is_same_v<T, float>) return 4;
-		else if constexpr (std::is_same_v<T, int>) return 5;
-		if constexpr (std::is_same_v<T, bool>) return 6;
-		return ~static_cast<uint32_t>(0UL);
-	};
-
-	for (auto&[name, prop] : m_target->GetProperties())
-	{
-		if (auto program = m_target->GetProgram(); !program || !program->GetUniformInfo(name))
-		{
-			// This property isn't used in the shader program, so skip it
-			continue;
-		}
-
-		// Uniforms starting with '_' are internal (private), so not exposed
-		if (name.length() == 0 || name[0] == '_')
-		{
-			continue;
-		}
-
-		const auto index = std::visit(typeIndexVisitor, prop.value);
-		sortedProperties.emplace(
-			index,
-			std::pair<std::string, std::reference_wrapper<OvRendering::Data::MaterialPropertyType>>{ 
-				name,
-				std::ref(prop.value)
-		});
-	}
-
-	for (auto& [index, propInfo] : sortedProperties)
-	{
-		const auto& name = propInfo.first;
-		auto& prop = propInfo.second.get();
-
-		const auto formattedType = FormatPropertyName(name);
-
-		// Create a visitor to handle each type in the variant
-		auto drawVisitor = [&](auto& arg) {
-			using T = std::decay_t<decltype(arg)>;
-
-			if constexpr (std::is_same_v<T, bool>)
-			{
-				GUIDrawer::DrawBoolean(*m_shaderSettingsColumns, formattedType, arg);
-			}
-			else if constexpr (std::is_same_v<T, int>)
-			{
-				GUIDrawer::DrawScalar<int>(*m_shaderSettingsColumns, formattedType, arg);
-			}
-			else if constexpr (std::is_same_v<T, float>)
-			{
-				GUIDrawer::DrawScalar<float>(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-			}
-			else if constexpr (std::is_same_v<T, OvMaths::FVector2>)
-			{
-				GUIDrawer::DrawVec2(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-			}
-			else if constexpr (std::is_same_v<T, OvMaths::FVector3>)
-			{
-				DrawHybridVec3(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-			}
-			else if constexpr (std::is_same_v<T, OvMaths::FVector4>)
-			{
-				DrawHybridVec4(*m_shaderSettingsColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
-			}
-			else if constexpr (std::is_same_v<T, Texture*>)
-			{
-				GUIDrawer::DrawTexture(*m_shaderSettingsColumns, formattedType, arg);
-			}
-			// No UI for TextureHandle* since it's not handled in the original code
-		};
-
-		// Apply the visitor to the variant
-		std::visit(drawVisitor, prop);
-	}
+	m_materialProperties = &m_settings->CreateWidget<Layout::GroupCollapsable>("Properties");
+	m_materialPropertiesColumns = &m_materialProperties->CreateWidget<OvUI::Widgets::Layout::Columns<2>>();
+	m_materialPropertiesColumns->widths[0] = 150;
 }
 
 void OvEditor::Panels::MaterialEditor::GenerateMaterialSettingsContent()
@@ -430,7 +341,7 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialSettingsContent()
 
 void OvEditor::Panels::MaterialEditor::GenerateMaterialFeaturesContent()
 {
-	m_featureSettingsColumns->RemoveAllWidgets();
+	m_materialFeaturesColumns->RemoveAllWidgets();
 
 	if (m_target && m_target->GetShader())
 	{
@@ -440,7 +351,7 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialFeaturesContent()
 		for (const auto& feature : features)
 		{
 			GUIDrawer::DrawBoolean(
-				*m_featureSettingsColumns,
+				*m_materialFeaturesColumns,
 				feature,
 				[this, feature]() -> bool {
 					return m_target->HasFeature(feature);
@@ -449,15 +360,113 @@ void OvEditor::Panels::MaterialEditor::GenerateMaterialFeaturesContent()
 					if (p_enabled)
 					{
 						m_target->AddFeature(feature);
-						GenerateShaderSettingsContent();
+						GenerateMaterialPropertiesContent();
 					}
 					else
 					{
 						m_target->RemoveFeature(feature);
-						GenerateShaderSettingsContent();
+						GenerateMaterialPropertiesContent();
 					}
 				}
 			);
 		}
+	}
+}
+
+void OvEditor::Panels::MaterialEditor::GenerateMaterialPropertiesContent()
+{
+	using namespace OvRendering::Settings;
+	using namespace OvRendering::Resources;
+
+	m_materialPropertiesColumns->RemoveAllWidgets(); // Ensure that the m_shaderSettingsColumns is empty
+
+	std::multimap<
+		int,
+		std::pair<
+		std::string,
+		std::reference_wrapper<OvRendering::Data::MaterialPropertyType>
+		>
+	> sortedProperties;
+
+	auto typeIndexVisitor = [&](auto& arg) -> uint32_t {
+		using T = std::decay_t<decltype(arg)>;
+
+		if constexpr (std::is_same_v<T, Texture*>) return 0;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector4>) return 1;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector3>) return 2;
+		else if constexpr (std::is_same_v<T, OvMaths::FVector2>) return 3;
+		else if constexpr (std::is_same_v<T, float>) return 4;
+		else if constexpr (std::is_same_v<T, int>) return 5;
+		if constexpr (std::is_same_v<T, bool>) return 6;
+		return ~static_cast<uint32_t>(0UL);
+	};
+
+	for (auto& [name, prop] : m_target->GetProperties())
+	{
+		if (auto program = m_target->GetProgram(); !program || !program->GetUniformInfo(name))
+		{
+			// This property isn't used in the shader program, so skip it
+			continue;
+		}
+
+		// Uniforms starting with '_' are internal (private), so not exposed
+		if (name.length() == 0 || name[0] == '_')
+		{
+			continue;
+		}
+
+		sortedProperties.emplace(
+			std::visit(typeIndexVisitor, prop.value),
+			std::pair<std::string, std::reference_wrapper<OvRendering::Data::MaterialPropertyType>>{
+				name,
+				std::ref(prop.value)
+			}
+		);
+	}
+
+	for (auto& [index, propInfo] : sortedProperties)
+	{
+		const auto& name = propInfo.first;
+		auto& prop = propInfo.second.get();
+
+		const auto formattedType = FormatPropertyName(name);
+
+		// Create a visitor to handle each type in the variant
+		auto drawVisitor = [&](auto& arg) {
+			using T = std::decay_t<decltype(arg)>;
+
+			if constexpr (std::is_same_v<T, bool>)
+			{
+				GUIDrawer::DrawBoolean(*m_materialPropertiesColumns, formattedType, arg);
+			}
+			else if constexpr (std::is_same_v<T, int>)
+			{
+				GUIDrawer::DrawScalar<int>(*m_materialPropertiesColumns, formattedType, arg);
+			}
+			else if constexpr (std::is_same_v<T, float>)
+			{
+				GUIDrawer::DrawScalar<float>(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector2>)
+			{
+				GUIDrawer::DrawVec2(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector3>)
+			{
+				DrawHybridVec3(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, OvMaths::FVector4>)
+			{
+				DrawHybridVec4(*m_materialPropertiesColumns, formattedType, arg, 0.01f, GUIDrawer::_MIN_FLOAT, GUIDrawer::_MAX_FLOAT);
+			}
+			else if constexpr (std::is_same_v<T, Texture*>)
+			{
+				GUIDrawer::DrawTexture(*m_materialPropertiesColumns, formattedType, arg);
+			}
+			// No UI for TextureHandle* since it's not handled in the original code
+			};
+
+		// Apply the visitor to the variant
+		std::visit(drawVisitor, prop);
 	}
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -61,6 +61,14 @@ namespace OvRendering::Data
 		void SetShader(OvRendering::Resources::Shader* p_shader);
 
 		/**
+		* Returns the shader program (variant) given the current feature set
+		* @param p_override
+		*/
+		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> GetProgram(
+			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_override = std::nullopt
+		) const;
+
+		/**
 		* Fill uniform with default uniform values
 		*/
 		void FillUniform();

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -89,12 +89,27 @@ namespace OvRendering::Data
 		void Unbind() const;
 
 		/**
+		* Returns true if the material has a given property
+		* @param p_name
+		*/
+		bool HasProperty(const std::string& p_name) const;
+
+		/**
 		* Sets a material property value
+		* @note This method expects that the property already exists. If unsure, use TrySetProperty instead.
 		* @param p_name
 		* @param p_value
 		* @param p_singleUse (automatically consume the value after the first use)
 		*/
 		void SetProperty(const std::string p_name, const MaterialPropertyType& p_value, bool p_singleUse = false);
+
+		/**
+		* Sets a material property value if the property exists
+		* @param p_name
+		* @param p_value
+		* @param p_singleUse (automatically consume the value after the first use)
+		*/
+		bool TrySetProperty(const std::string& p_name, const MaterialPropertyType& p_value, bool p_singleUse = false);
 
 		/**
 		* Gets a material property

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -81,6 +81,20 @@ void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_sh
 	}
 }
 
+OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> OvRendering::Data::Material::GetProgram(
+	OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_override
+) const
+{
+	if (m_shader)
+	{
+		return m_shader->GetProgram(
+			p_override.value_or(m_features)
+		);
+	}
+	
+	return std::nullopt;
+}
+
 void OvRendering::Data::Material::FillUniform()
 {
 	m_properties.clear();

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -228,23 +228,33 @@ void OvRendering::Data::Material::Unbind() const
 	m_shader->GetProgram().Unbind();
 }
 
+bool OvRendering::Data::Material::HasProperty(const std::string& p_name) const
+{
+	OVASSERT(IsValid(), "Attempting to call HasProperty on an invalid material.");
+	return m_properties.contains(p_name);
+}
+
 void OvRendering::Data::Material::SetProperty(const std::string p_name, const MaterialPropertyType& p_value, bool p_singleUse)
 {
 	OVASSERT(IsValid(), "Attempting to SetProperty on an invalid material.");
+	OVASSERT(HasProperty(p_name), "Attempting to SetProperty on a non-existing property.");
+	const auto property = 
 
-	if (m_properties.find(p_name) != m_properties.end())
-	{
-		const auto property = MaterialProperty{
-			p_value,
-			p_singleUse
-		};
+	m_properties[p_name] = MaterialProperty{
+		p_value,
+		p_singleUse
+	};
+}
 
-		m_properties[p_name] = property;
-	}
-	else
+bool OvRendering::Data::Material::TrySetProperty(const std::string& p_name, const MaterialPropertyType& p_value, bool p_singleUse)
+{
+	if (HasProperty(p_name))
 	{
-		OVLOG_ERROR("Material Set failed: Uniform not found");
+		SetProperty(p_name, p_value, p_singleUse);
+		return true;
 	}
+
+	return false;
 }
 
 OvTools::Utils::OptRef<const OvRendering::Data::MaterialProperty> OvRendering::Data::Material::GetProperty(const std::string p_key) const


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Settings that aren't available to the currently selected variant (based off the enabled shader features), are now hidden
* Material serialization flow updated to skip properties that aren't used by the current variant
* Added warning when a shadow receiver doesn't have the right uniforms
* Cleaned up material editor and renamed sections
* Cleaned up atmospheric scattering shader (removed unused code)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/c9329dd9-a3e1-48fe-8b1a-885ee6244902


