### PR TITLE
[WIP] Fixed feature set override in shadow, outline, and picking passes

### DIFF
--- a/Resources/Engine/Shaders/Lambert.ovfx
+++ b/Resources/Engine/Shaders/Lambert.ovfx
@@ -17,21 +17,13 @@ out VS_OUT
     vec3 Normal;
 } vs_out;
 
-#if defined(SHADOW_PASS)
-uniform mat4 _LightSpaceMatrix;
-#endif
-
 void main()
 {
     vs_out.FragPos = vec3(ubo_Model * vec4(geo_Pos, 1.0));
     vs_out.TexCoords = geo_TexCoords;
     vs_out.Normal = normalize(mat3(transpose(inverse(ubo_Model))) * geo_Normal);
 
-#if defined(SHADOW_PASS)
-    gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
-#else
     gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
-#endif
 }
 
 #shader fragment

--- a/Resources/Engine/Shaders/ShadowFallback.ovfx
+++ b/Resources/Engine/Shaders/ShadowFallback.ovfx
@@ -5,11 +5,9 @@ layout (location = 0) in vec3 geo_Pos;
 
 #include ":Shaders/Common/Buffers/EngineUBO.ovfxh"
 
-uniform mat4 _LightSpaceMatrix;
-
 void main()
 {
-    gl_Position = _LightSpaceMatrix * ubo_Model * vec4(geo_Pos, 1.0);
+    gl_Position = ubo_Projection * ubo_View * ubo_Model * vec4(geo_Pos, 1.0);
 }
 
 #shader fragment

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -27,10 +27,6 @@ out VS_OUT
 #endif
 } vs_out;
 
-#if defined(SHADOW_PASS)
-uniform mat4 _LightSpaceMatrix;
-#endif
-
 void main()
 {
     vs_out.FragPos = vec3(ubo_Model * vec4(geo_Pos, 1.0));
@@ -43,11 +39,7 @@ void main()
     vs_out.TangentFragPos = transpose(vs_out.TBN) * vs_out.FragPos;
 #endif
 
-#if defined(SHADOW_PASS)
-    gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
-#else
     gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
-#endif
 }
 
 #shader fragment

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -27,10 +27,6 @@ out VS_OUT
 #endif
 } vs_out;
 
-#if defined(SHADOW_PASS)
-uniform mat4 _LightSpaceMatrix;
-#endif
-
 void main()
 {
     vs_out.FragPos = vec3(ubo_Model * vec4(geo_Pos, 1.0));
@@ -43,11 +39,7 @@ void main()
     vs_out.TangentFragPos = transpose(vs_out.TBN) * vs_out.FragPos;
 #endif
 
-#if defined(SHADOW_PASS)
-    gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
-#else
     gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
-#endif
 }
 
 #shader fragment

--- a/Resources/Engine/Shaders/Unlit.ovfx
+++ b/Resources/Engine/Shaders/Unlit.ovfx
@@ -16,20 +16,12 @@ out VS_OUT
     vec2 TexCoords;
 } vs_out;
 
-#if defined(SHADOW_PASS)
-uniform mat4 _LightSpaceMatrix;
-#endif
-
 void main()
 {
     vs_out.FragPos = vec3(ubo_Model * vec4(geo_Pos, 1.0));
     vs_out.TexCoords = geo_TexCoords;
 
-#if defined(SHADOW_PASS)
-    gl_Position = _LightSpaceMatrix * vec4(vs_out.FragPos, 1.0);
-#else
     gl_Position = ubo_Projection * ubo_View * vec4(vs_out.FragPos, 1.0);
-#endif
 }
 
 #shader fragment

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/EngineBufferRenderFeature.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/EngineBufferRenderFeature.h
@@ -6,8 +6,9 @@
 
 #pragma once
 
-#include <map>
 #include <chrono>
+#include <map>
+#include <stack>
 
 #include <OvRendering/Features/ARenderFeature.h>
 #include <OvRendering/HAL/UniformBuffer.h>
@@ -27,6 +28,12 @@ namespace OvCore::Rendering
 		*/
 		EngineBufferRenderFeature(OvRendering::Core::CompositeRenderer& p_renderer);
 
+		/**
+		* Replace the current camera data in the engine buffer by the provided camera
+		* @param p_camera
+		*/
+		void SetCamera(const OvRendering::Entities::Camera& p_camera);
+
 	protected:
 		virtual void OnBeginFrame(const OvRendering::Data::FrameDescriptor& p_frameDescriptor) override;
 		virtual void OnEndFrame() override;
@@ -35,6 +42,5 @@ namespace OvCore::Rendering
 	protected:
 		std::chrono::high_resolution_clock::time_point m_startTime;
 		std::unique_ptr<OvRendering::HAL::UniformBuffer> m_engineBuffer;
-		OvRendering::Data::FrameDescriptor m_cachedFrameDescriptor;
 	};
 }

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/ShadowRenderPass.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/ShadowRenderPass.h
@@ -36,8 +36,7 @@ namespace OvCore::Rendering
 
 		void DrawShadows(
 			OvRendering::Data::PipelineState p_pso,
-			OvCore::SceneSystem::Scene& p_scene,
-			const OvMaths::FMatrix4& p_lightSpaceMatrix
+			OvCore::SceneSystem::Scene& p_scene
 		);
 
 	private:

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
@@ -41,14 +41,18 @@ void OvCore::Rendering::ShadowRenderFeature::OnBeforeDraw(OvRendering::Data::Pip
 				{
 					if (light.type == OvRendering::Settings::ELightType::DIRECTIONAL)
 					{
-						const auto shadowTex = light.GetShadowBuffer().GetAttachment<OvRendering::HAL::Texture>(OvRendering::Settings::EFramebufferAttachment::DEPTH);
+						OVASSERT(light.IsSetupForShadowRendering(), "This light isn't setup for shadow rendering");
+
+						const auto shadowTex = light.shadowBuffer->GetAttachment<OvRendering::HAL::Texture>(
+							OvRendering::Settings::EFramebufferAttachment::DEPTH
+						);
 
 						if (!material.TrySetProperty("_ShadowMap", &shadowTex.value(), true))
 						{
 							OVLOG_WARNING("ShadowRenderFeature: Material does not have a _ShadowMap property");
 						}
 
-						if (!material.TrySetProperty("_LightSpaceMatrix", light.GetLightSpaceMatrix(), true))
+						if (!material.TrySetProperty("_LightSpaceMatrix", light.lightSpaceMatrix.value(), true))
 						{
 							OVLOG_WARNING("ShadowRenderFeature: Material does not have a _LightSpaceMatrix property");
 						}

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
@@ -126,8 +126,9 @@ void OvCore::Rendering::ShadowRenderPass::DrawShadows(
 							drawable.stateMask.depthTest = true; // The shadow pass should always use depth test.
 							drawable.stateMask.colorWriting = false; // The shadow pass should never write color.
 							drawable.stateMask.depthWriting = true; // The shadow pass should always write depth.
-							// No front/backface culling for shadow pass.
-							// A "two-sided" shadow pass setting could be added in the future, to change this behavior.
+
+							// No front/backface culling for shadow pass (aka: two-sided shadow pass).
+							// A "two-sided" shadow pass setting could be added in the future to change this behavior.
 							drawable.stateMask.frontfaceCulling = false;
 							drawable.stateMask.backfaceCulling = false;
 

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
@@ -129,7 +129,8 @@ void OvCore::Rendering::ShadowRenderPass::DrawShadows(
 							drawable.stateMask.frontfaceCulling = false;
 							drawable.stateMask.backfaceCulling = false;
 
-							drawable.featureSetOverride = { shadowPassName };
+							drawable.featureSetOverride = targetMaterial.GetFeatures() + shadowPassName;
+
 							drawable.AddDescriptor<EngineDrawableDescriptor>({
 								modelMatrix,
 								materialRenderer->GetUserMatrix()

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -464,7 +464,7 @@ protected:
 			pso,
 			data.transform->GetWorldPosition(),
 			data.transform->GetWorldRotation(),
-			data.GetEffectRange(),
+			data.CalculateEffectRange(),
 			kDebugBoundsColor,
 			1.0f
 		);
@@ -482,7 +482,7 @@ protected:
 			p_ambientBoxLight.owner.transform.GetWorldPosition(),
 			data.transform->GetWorldRotation(),
 			{ data.constant, data.linear, data.quadratic },
-			data.GetEffectRange(),
+			data.CalculateEffectRange(),
 			1.0f
 		);
 	}

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
@@ -178,7 +178,8 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelToStencil(
 		element.stateMask = stateMask;
 		element.stateMask.depthTest = false;
 		element.stateMask.colorWriting = false;
-		element.featureSetOverride = { outlinePassName };
+		element.featureSetOverride = targetMaterial.GetFeatures() + outlinePassName;
+
 		element.AddDescriptor(engineDrawableDescriptor);
 
 		m_renderer.DrawEntity(p_pso, element);
@@ -221,14 +222,15 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelOutline(
 			OvMaths::FMatrix4::Identity
 		};
 
-		OvRendering::Entities::Drawable element;
-		element.mesh = *mesh;
-		element.material = targetMaterial;
-		element.stateMask = stateMask;
-		element.stateMask.depthTest = false;
-		element.featureSetOverride = { outlinePassName };
-		element.AddDescriptor(engineDrawableDescriptor);
+		OvRendering::Entities::Drawable drawable;
+		drawable.mesh = *mesh;
+		drawable.material = targetMaterial;
+		drawable.stateMask = stateMask;
+		drawable.stateMask.depthTest = false;
+		drawable.featureSetOverride = targetMaterial.GetFeatures() + outlinePassName;
 
-		m_renderer.DrawEntity(p_pso, element);
+		drawable.AddDescriptor(engineDrawableDescriptor);
+
+		m_renderer.DrawEntity(p_pso, drawable);
 	}
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -186,7 +186,7 @@ void OvEditor::Rendering::PickingRenderPass::DrawPickableModels(
 						drawable.stateMask = stateMask;
 						drawable.stateMask.frontfaceCulling = false;
 						drawable.stateMask.backfaceCulling = false;
-						drawable.featureSetOverride = { pickingPassName };
+						drawable.featureSetOverride = targetMaterial.GetFeatures() + pickingPassName;
 
 						drawable.AddDescriptor<OvCore::Rendering::EngineDrawableDescriptor>({
 							modelMatrix

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/FeatureSet.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/FeatureSet.h
@@ -1,0 +1,39 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace OvRendering::Data
+{
+	using FeatureSet = std::unordered_set<std::string>;
+
+	struct FeatureSetHash
+	{
+		size_t operator()(const FeatureSet& fs) const;
+	};
+
+	struct FeatureSetEqual
+	{
+		bool operator()(const FeatureSet& lhs, const FeatureSet& rhs) const;
+	};
+}
+
+/**
+* Convenience operator to add a feature to a set
+* @param p_lhs
+* @param p_feature
+*/
+OvRendering::Data::FeatureSet operator+(const OvRendering::Data::FeatureSet& p_lhs, const std::string& p_feature);
+
+/**
+* Convenience operator to remove a feature from a set
+* @param p_lhs
+* @param p_feature
+*/
+OvRendering::Data::FeatureSet operator-(const OvRendering::Data::FeatureSet& p_lhs, const std::string& p_feature);

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -65,7 +65,7 @@ namespace OvRendering::Data
 		* @param p_override
 		*/
 		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> GetProgram(
-			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_override = std::nullopt
+			OvTools::Utils::OptRef<const Data::FeatureSet> p_override = std::nullopt
 		) const;
 
 		/**
@@ -80,7 +80,7 @@ namespace OvRendering::Data
 		*/
 		void Bind(
 			HAL::Texture* p_emptyTexture = nullptr,
-			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_featureSetOverride = std::nullopt
+			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt
 		);
 
 		/**
@@ -267,7 +267,7 @@ namespace OvRendering::Data
 		/**
 		* Returns the feature set of this material
 		*/
-		Resources::Shader::FeatureSet& GetFeatures();
+		Data::FeatureSet& GetFeatures();
 
 		/**
 		* Adds a feature to the material
@@ -296,7 +296,7 @@ namespace OvRendering::Data
 	protected:
 		OvRendering::Resources::Shader* m_shader = nullptr;
 		PropertyMap m_properties;
-		Resources::Shader::FeatureSet m_features;
+		Data::FeatureSet m_features;
 
 		bool m_userInterface = false;
 		bool m_blendable = false;

--- a/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
@@ -6,12 +6,10 @@
 
 #pragma once
 
-#include <OvMaths/FTransform.h> // TODO: Unused right now, might want to use it instead of model matrix
+#include <OvRendering/Data/Describable.h>
+#include <OvRendering/Data/Material.h>
+#include <OvRendering/Resources/IMesh.h>
 #include <OvTools/Utils/OptRef.h>
-
-#include "OvRendering/Resources/Mesh.h"
-#include "OvRendering/Data/Material.h"
-#include "OvRendering/Data/Describable.h"
 
 namespace OvRendering::Entities
 {
@@ -24,6 +22,6 @@ namespace OvRendering::Entities
 		OvTools::Utils::OptRef<OvRendering::Data::Material> material;
 		Data::StateMask stateMask;
 		Settings::EPrimitiveMode primitiveMode = OvRendering::Settings::EPrimitiveMode::TRIANGLES;
-		std::optional<Resources::Shader::FeatureSet> featureSetOverride = std::nullopt;
+		std::optional<Data::FeatureSet> featureSetOverride = std::nullopt;
 	};
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Entities/Light.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Entities/Light.h
@@ -10,11 +10,12 @@
 #include <OvMaths/FMatrix4.h>
 #include <OvMaths/FTransform.h>
 
-#include "OvRendering/Entities/Entity.h"
-#include "OvRendering/Settings/ELightType.h"
-#include "OvRendering/Resources/Texture.h"
-#include "OvRendering/HAL/Framebuffer.h"
+#include <OvRendering/Data/FrameDescriptor.h>
 #include <OvRendering/Entities/Camera.h>
+#include <OvRendering/Entities/Entity.h>
+#include <OvRendering/HAL/Framebuffer.h>
+#include <OvRendering/Resources/Texture.h>
+#include <OvRendering/Settings/ELightType.h>
 
 namespace OvRendering::Entities
 {
@@ -37,22 +38,19 @@ namespace OvRendering::Entities
 		bool shadowFollowCamera = true;
 		int16_t shadowMapResolution = 8192;
 
-		/**
-		* Update the content of the shadow cache
-		* @param p_shadowMapResolution
-		* @param p_camera
-		*/
-		void UpdateShadowData(const OvRendering::Entities::Camera& p_camera);
+		std::unique_ptr<OvRendering::HAL::Framebuffer> shadowBuffer;
+		std::optional<OvRendering::Entities::Camera> shadowCamera;
+		std::optional<OvMaths::FMatrix4> lightSpaceMatrix;
 
 		/**
-		* Returns the light space matrix
+		* Generate and cache light space matrix for the light
 		*/
-		const OvMaths::FMatrix4& GetLightSpaceMatrix() const;
+		void PrepareForShadowRendering(const OvRendering::Data::FrameDescriptor& p_frameDescriptor);
 
 		/**
-		* Returns the framebuffer used to render the shadow map
+		* Returns true if the light is setup for shadow rendering
 		*/
-		const OvRendering::HAL::Framebuffer& GetShadowBuffer() const;
+		bool IsSetupForShadowRendering() const;
 
 		/**
 		* Generate the light matrix, ready to send to the GPU
@@ -62,9 +60,6 @@ namespace OvRendering::Entities
 		/**
 		* Calculate the light effect range from the quadratic falloff equation
 		*/
-		float GetEffectRange() const;
-
-		OvMaths::FMatrix4 lightSpaceMatrix;
-		std::unique_ptr<OvRendering::HAL::Framebuffer> shadowBuffer;
+		float CalculateEffectRange() const;
 	};
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
@@ -11,6 +11,7 @@
 #include <unordered_set>
 #include <unordered_map>
 
+#include <OvRendering/Data/FeatureSet.h>
 #include <OvRendering/HAL/ShaderProgram.h>
 
 namespace OvRendering::Resources
@@ -26,35 +27,23 @@ namespace OvRendering::Resources
 		friend class Loaders::ShaderLoader;
 
 	public:
-		using FeatureSet = std::unordered_set<std::string>;
-
-		struct FeatureSetHash
-		{
-			size_t operator()(const FeatureSet& fs) const;
-		};
-
-		struct FeatureSetEqual
-		{
-			bool operator()(const FeatureSet& lhs, const FeatureSet& rhs) const;
-		};
-
 		using ProgramVariants = std::unordered_map<
-			FeatureSet,
+			Data::FeatureSet,
 			std::unique_ptr<HAL::ShaderProgram>,
-			FeatureSetHash,
-			FeatureSetEqual
+			Data::FeatureSetHash,
+			Data::FeatureSetEqual
 		>;
 
 		/**
 		* Returns the associated shader program for a given feature set
 		* @param p_featureSet (optional) The feature set to use. If not provided, the default program will be used.
 		*/
-		HAL::ShaderProgram& GetProgram(const FeatureSet& p_featureSet = {});
+		HAL::ShaderProgram& GetProgram(const Data::FeatureSet& p_featureSet = {});
 
 		/**
 		* Returns supported features
 		*/
-		const FeatureSet& GetFeatures() const;
+		const Data::FeatureSet& GetFeatures() const;
 
 		/**
 		* Return all programs
@@ -74,7 +63,7 @@ namespace OvRendering::Resources
 		const std::string path;
 
 	private:
-		FeatureSet m_features;
+		Data::FeatureSet m_features;
 		ProgramVariants m_programs;
 	};
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -214,7 +214,7 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 		material->Bind(
 			&m_emptyTexture->GetTexture(),
 			p_drawable.featureSetOverride.has_value() ?
-			OvTools::Utils::OptRef<const Resources::Shader::FeatureSet>(p_drawable.featureSetOverride.value()) :
+			OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
 			std::nullopt
 		);
 

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/FeatureSet.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/FeatureSet.cpp
@@ -1,0 +1,41 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#include <OvRendering/Data/FeatureSet.h>
+
+namespace OvRendering::Data
+{
+	size_t FeatureSetHash::operator()(const FeatureSet& fs) const
+	{
+		size_t hash = 0;
+
+		for (const auto& feature : fs)
+		{
+			hash ^= std::hash<std::string>{}(feature);
+		}
+
+		return hash;
+	}
+
+	bool FeatureSetEqual::operator()(const FeatureSet& lhs, const FeatureSet& rhs) const
+	{
+		return lhs == rhs;
+	};
+}
+
+OvRendering::Data::FeatureSet operator+(const OvRendering::Data::FeatureSet& p_lhs, const std::string& p_feature)
+{
+	OvRendering::Data::FeatureSet result = p_lhs;
+	result.insert(p_feature);
+	return result;
+}
+
+OvRendering::Data::FeatureSet operator-(const OvRendering::Data::FeatureSet& p_lhs, const std::string& p_feature)
+{
+	OvRendering::Data::FeatureSet result = p_lhs;
+	result.erase(p_feature);
+	return result;
+}

--- a/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Data/Material.cpp
@@ -82,7 +82,7 @@ void OvRendering::Data::Material::SetShader(OvRendering::Resources::Shader* p_sh
 }
 
 OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> OvRendering::Data::Material::GetProgram(
-	OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_override
+	OvTools::Utils::OptRef<const Data::FeatureSet> p_override
 ) const
 {
 	if (m_shader)
@@ -113,7 +113,7 @@ void OvRendering::Data::Material::FillUniform()
 
 void OvRendering::Data::Material::Bind(
 	OvRendering::HAL::Texture* p_emptyTexture,
-	OvTools::Utils::OptRef<const Resources::Shader::FeatureSet> p_featureSetOverride
+	OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride
 )
 {
 	ZoneScoped;
@@ -413,7 +413,7 @@ OvRendering::Data::Material::PropertyMap& OvRendering::Data::Material::GetProper
 	return m_properties;
 }
 
-OvRendering::Resources::Shader::FeatureSet& OvRendering::Data::Material::GetFeatures()
+OvRendering::Data::FeatureSet& OvRendering::Data::Material::GetFeatures()
 {
 	return m_features;
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Features/LightingRenderFeature.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Features/LightingRenderFeature.cpp
@@ -16,14 +16,14 @@ OvRendering::Features::LightingRenderFeature::LightingRenderFeature(Core::Compos
 bool IsLightInFrustum(const OvRendering::Entities::Light& p_light, const OvRendering::Data::Frustum& p_frustum)
 {
 	const auto& position = p_light.transform->GetWorldPosition();
-	const auto effectRange = p_light.GetEffectRange();
+	const auto effectRange = p_light.CalculateEffectRange();
 
 	// We always consider lights that have an +inf range (Not necessary to test if they are in frustum)
 	const bool isOmniscientLight = std::isinf(effectRange);
 
 	return
 		isOmniscientLight ||
-		p_frustum.SphereInFrustum(position.x, position.y, position.z, p_light.GetEffectRange());
+		p_frustum.SphereInFrustum(position.x, position.y, position.z, effectRange);
 }
 
 void OvRendering::Features::LightingRenderFeature::OnBeginFrame(const Data::FrameDescriptor& p_frameDescriptor)

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -62,7 +62,7 @@ namespace
 		const ShaderInputInfo inputInfo;
 		const std::string vertexShader;
 		const std::string fragmentShader;
-		const OvRendering::Resources::Shader::FeatureSet features;
+		const OvRendering::Data::FeatureSet features;
 	};
 
 	struct ShaderAssembleResult
@@ -96,7 +96,7 @@ namespace
 		return std::string{ view.begin(), view.end() };
 	}
 
-	std::string FeatureSetToString(const OvRendering::Resources::Shader::FeatureSet& features)
+	std::string FeatureSetToString(const OvRendering::Data::FeatureSet& features)
 	{
 		if (!features.empty())
 		{
@@ -111,7 +111,7 @@ namespace
 		return std::string{};
 	}
 
-	std::string EnableFeaturesInShaderCode(const std::string& shaderCode, const OvRendering::Resources::Shader::FeatureSet& features)
+	std::string EnableFeaturesInShaderCode(const std::string& shaderCode, const OvRendering::Data::FeatureSet& features)
 	{
 		if (features.empty())
 		{
@@ -150,7 +150,7 @@ namespace
 	std::unique_ptr<OvRendering::HAL::ShaderProgram> CreateProgram(
 		const ShaderInputInfo& p_shaderInputInfo,
 		std::span<const ShaderStageDesc> p_stages,
-		const OvRendering::Resources::Shader::FeatureSet& p_features,
+		const OvRendering::Data::FeatureSet& p_features,
 		bool p_disableLogging = false
 	)
 	{
@@ -367,7 +367,7 @@ void main()
 		std::istringstream stream(p_shaderLoadResult.source); // Add this line to create a stringstream from shaderCode
 		std::string line;
 		std::unordered_map<EShaderType, std::stringstream> shaderSources;
-		OvRendering::Resources::Shader::FeatureSet features;
+		OvRendering::Data::FeatureSet features;
 
 		auto currentType = EShaderType::NONE;
 
@@ -426,7 +426,7 @@ void main()
 		// The number of combinations is 2^n, where n is the number of features.
 		for (size_t i = 0; i < variantCount; ++i)
 		{
-			OvRendering::Resources::Shader::FeatureSet featureSet;
+			OvRendering::Data::FeatureSet featureSet;
 			for (size_t j = 0; j < p_parseResult.features.size(); ++j)
 			{
 				if (i & (size_t{ 1UL } << j))
@@ -460,7 +460,7 @@ void main()
 		if (!variants.contains({}))
 		{
 			variants.emplace(
-				OvRendering::Resources::Shader::FeatureSet{},
+				OvRendering::Data::FeatureSet{},
 				std::move(CreateDefaultProgram())
 			);
 		}

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Shader.cpp
@@ -17,24 +17,7 @@ namespace
 	}
 }
 
-size_t OvRendering::Resources::Shader::FeatureSetHash::operator()(const FeatureSet& fs) const
-{
-	size_t hash = 0;
-
-	for (const auto& feature : fs)
-	{
-		hash ^= std::hash<std::string>{}(feature);
-	}
-
-	return hash;
-}
-
-bool OvRendering::Resources::Shader::FeatureSetEqual::operator()(const FeatureSet& lhs, const FeatureSet& rhs) const
-{
-	return lhs == rhs;
-};
-
-OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram(const FeatureSet& p_featureSet)
+OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram(const Data::FeatureSet& p_featureSet)
 {
 	if (m_programs.contains(p_featureSet))
 	{
@@ -47,7 +30,7 @@ OvRendering::HAL::ShaderProgram& OvRendering::Resources::Shader::GetProgram(cons
 	}
 }
 
-const OvRendering::Resources::Shader::FeatureSet& OvRendering::Resources::Shader::GetFeatures() const
+const OvRendering::Data::FeatureSet& OvRendering::Resources::Shader::GetFeatures() const
 {
 	return m_features;
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Instead of completely overriding the current feature set of a material when rendering a special pass (shadow, outline, picking), this PR ensures the material feature set is preserved, and the feature associated with the pass is added on top.
This way, effects bound to features (e.g. parallax), can still be used during special passes (e.g. shadows).

The engine UBO has been updated to support on-the-fly view/camera changes, this way, the shadow pass can override the view info by providing the light data (will be necessary for reflection probes too).

## To-Do
- [x] The engine UBO isn't updated to use the light's pos as the view pos, which breaks shader code relying on `ubo_ViewPos`.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.