### PR TITLE
Fixed crash with parallax mapping when an object is scaled to 0

### DIFF
--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -21,14 +21,18 @@ bool IsOrthographic(mat4 projectionMatrix)
 
 // Expects a height map with values in the range [0, 1].
 // 1.0 means the height is at the maximum depth, 0.0 means the height is at the minimum depth.
-vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale)
+vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale, int minLayers, int maxLayers)
 {
     const vec3 viewDir = normalize(tangentViewPos - tangentFragPos);
 
-    // number of depth layers
-    const float minLayers = 8;
-    const float maxLayers = 64;
-    const float numLayers = mix(maxLayers, minLayers, abs(dot(vec3(0.0, 0.0, 1.0), viewDir)));  
+    // calculate optimal layer count
+    minLayers = max(minLayers, 1); // Ensure minLayers is at least 1
+    maxLayers = min(maxLayers, 8192); // Limit maxLayers to a reasonable value (2^13)
+    maxLayers = max(maxLayers, minLayers); // Ensure maxLayers is at least minLayers
+
+    // clamp alpha to prevent extrapolating (which could make the fragment very expensive, and potentially result in a crash).
+    const float alpha = clamp(abs(dot(vec3(0.0, 0.0, 1.0), viewDir)), 0.0, 1.0);
+    const float numLayers = mix(maxLayers, minLayers, alpha);
 
     // calculate the size of each layer
     const float layerDepth = 1.0 / numLayers;

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -71,6 +71,8 @@ uniform float u_Shininess = 100.0;
 
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
+uniform int u_MinLayers = 8;
+uniform int u_MaxLayers = 64;
 uniform bool u_ParallaxClipEdges = false;
 uniform float u_HeightScale = 0.05;
 #endif
@@ -98,7 +100,7 @@ void main()
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
-    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale, u_MinLayers, u_MaxLayers);
     if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, ubo_Projection))
     {
         discard;

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -74,6 +74,8 @@ uniform sampler2D u_MaskMap;
 #if defined(PARALLAX_MAPPING)
 uniform sampler2D u_HeightMap;
 uniform bool u_ParallaxClipEdges = false;
+uniform int u_MinLayers = 8;
+uniform int u_MaxLayers = 64;
 uniform float u_HeightScale = 0.05;
 #endif
 
@@ -100,7 +102,7 @@ void main()
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
-    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale);
+    texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale, u_MinLayers, u_MaxLayers);
     if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, ubo_Projection))
     {
         discard;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Fixed crash when an object scale is set to 0 (resulting in parallax layer count to go through the roof)
* Exposed layer count (min & max) through material properties (final value clamped to avoid crashes)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #528 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/f8366ff1-0b09-4cd2-8366-25d581492222


