### PR TITLE
Exposed texture wrap and added support for parallax offset/tiling

### DIFF
--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -9,7 +9,7 @@ vec3 UnPack(float target)
 
 vec2 TileAndOffsetTexCoords(vec2 texCoords, vec2 tiling, vec2 offset)
 {
-    return vec2(mod(texCoords.x * tiling.x, 1), mod(texCoords.y * tiling.y, 1)) + offset;
+    return texCoords * tiling + offset;
 }
 
 bool IsOrthographic(mat4 projectionMatrix)
@@ -69,11 +69,13 @@ vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tan
     return finalTexCoords;
 }
 
-bool IsParallaxOutOfBounds(vec2 texCoords, mat4 projectionMatrix)
+bool IsParallaxOutOfBounds(vec2 texCoords, vec2 tiling, vec2 offset, mat4 projectionMatrix)
 {
+    const vec2 adjustedCoords = texCoords - offset;
+
     return
         !IsOrthographic(projectionMatrix) && // No clipping in orthographic projection (not supported)
-        (texCoords.x < 0.0 || texCoords.x > 1.0 || texCoords.y < 0.0 || texCoords.y > 1.0);
+        (adjustedCoords.x < 0.0 || adjustedCoords.x > tiling.x || adjustedCoords.y < 0.0 || adjustedCoords.y > tiling.y);
 }
 
 // [Deprecated] Kept for backward compatibility. Prefer using `ApplyParallaxOcclusionMapping()` instead.

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -101,7 +101,7 @@ void main()
 
 #if defined(PARALLAX_MAPPING)
     texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale, u_MinLayers, u_MaxLayers);
-    if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, ubo_Projection))
+    if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, u_TextureTiling, u_TextureOffset, ubo_Projection))
     {
         discard;
     }

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -103,7 +103,7 @@ void main()
 
 #if defined(PARALLAX_MAPPING)
     texCoords = ApplyParallaxOcclusionMapping(texCoords, u_HeightMap, fs_in.TangentViewPos, fs_in.TangentFragPos, u_HeightScale, u_MinLayers, u_MaxLayers);
-    if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, ubo_Projection))
+    if (u_ParallaxClipEdges && IsParallaxOutOfBounds(texCoords, u_TextureTiling, u_TextureOffset, ubo_Projection))
     {
         discard;
     }

--- a/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ResourceManagement/TextureManager.cpp
@@ -17,6 +17,8 @@ namespace
 	{
 		OvRendering::Settings::ETextureFilteringMode minFilter;
 		OvRendering::Settings::ETextureFilteringMode magFilter;
+		OvRendering::Settings::ETextureWrapMode horizontalWrap;
+		OvRendering::Settings::ETextureWrapMode verticalWrap;
 		bool generateMipmap;
 	};
 
@@ -24,12 +26,15 @@ namespace
 	{
 		using namespace OvRendering::Settings;
 		using enum ETextureFilteringMode;
+		using enum ETextureWrapMode;
 
 		const auto metaFile = OvTools::Filesystem::IniFile(std::format("{}.meta", p_filePath));
 
 		return TextureMetaData{
 			.minFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MIN_FILTER", static_cast<int>(LINEAR_MIPMAP_LINEAR))),
 			.magFilter = static_cast<ETextureFilteringMode>(metaFile.GetOrDefault("MAG_FILTER", static_cast<int>(LINEAR))),
+			.horizontalWrap = static_cast<ETextureWrapMode>(metaFile.GetOrDefault("HORIZONTAL_WRAP", static_cast<int>(REPEAT))),
+			.verticalWrap = static_cast<ETextureWrapMode>(metaFile.GetOrDefault("VERTICAL_WRAP", static_cast<int>(REPEAT))),
 			.generateMipmap = metaFile.GetOrDefault("ENABLE_MIPMAPPING", true)
 		};
 	}
@@ -45,6 +50,8 @@ OvRendering::Resources::Texture* OvCore::ResourceManagement::TextureManager::Cre
 		realPath,
 		metaData.minFilter,
 		metaData.magFilter,
+		metaData.horizontalWrap,
+		metaData.verticalWrap,
 		metaData.generateMipmap
 	);
 
@@ -70,6 +77,8 @@ void OvCore::ResourceManagement::TextureManager::ReloadResource(OvRendering::Res
 		realPath,
 		metaData.minFilter,
 		metaData.magFilter,
+		metaData.horizontalWrap,
+		metaData.verticalWrap,
 		metaData.generateMipmap
 	);
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorResources.cpp
@@ -21,6 +21,8 @@ namespace
 			p_path.string(),
 			FilteringMode,
 			FilteringMode,
+			OvRendering::Settings::ETextureWrapMode::REPEAT,
+			OvRendering::Settings::ETextureWrapMode::REPEAT,
 			false
 		);
 	}

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/AssetProperties.cpp
@@ -281,10 +281,14 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 
 	const std::string kMinFilter = "MIN_FILTER";
 	const std::string kMagFilter = "MAG_FILTER";
+	const std::string kHorizontalWrap = "HORIZONTAL_WRAP";
+	const std::string kVerticalWrap = "VERTICAL_WRAP";
 	const std::string kEnableMipmapping = "ENABLE_MIPMAPPING";
 
 	m_metadata->Add(kMinFilter, static_cast<int>(ETextureFilteringMode::LINEAR_MIPMAP_LINEAR));
 	m_metadata->Add(kMagFilter, static_cast<int>(ETextureFilteringMode::LINEAR));
+	m_metadata->Add(kHorizontalWrap, static_cast<int>(ETextureWrapMode::REPEAT));
+	m_metadata->Add(kVerticalWrap, static_cast<int>(ETextureWrapMode::REPEAT));
 	m_metadata->Add(kEnableMipmapping, true);
 
 	const auto filteringModes = std::map<int, std::string>{
@@ -299,17 +303,37 @@ void OvEditor::Panels::AssetProperties::CreateTextureSettings()
 	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settingsColumns, kMinFilter);
 	auto& minFilter = m_settingsColumns->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>(kMinFilter));
 	minFilter.choices = filteringModes;
-	minFilter.ValueChangedEvent += [this, kMinFilter](int p_choice)
-	{
+	minFilter.ValueChangedEvent += [this, kMinFilter](int p_choice) {
 		m_metadata->Set(kMinFilter, p_choice);
 	};
 
 	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settingsColumns, kMagFilter);
 	auto& magFilter = m_settingsColumns->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>(kMagFilter));
 	magFilter.choices = filteringModes;
-	magFilter.ValueChangedEvent += [this, kMagFilter](int p_choice)
-	{
+	magFilter.ValueChangedEvent += [this, kMagFilter](int p_choice) {
 		m_metadata->Set(kMagFilter, p_choice);
+	};
+
+	const auto wrapModes = std::map<int, std::string>{
+		{static_cast<int>(ETextureWrapMode::REPEAT), "REPEAT"},
+		{static_cast<int>(ETextureWrapMode::CLAMP_TO_EDGE), "CLAMP_TO_EDGE"},
+		{static_cast<int>(ETextureWrapMode::CLAMP_TO_BORDER), "CLAMP_TO_BORDER"},
+		{static_cast<int>(ETextureWrapMode::MIRRORED_REPEAT), "MIRRORED_REPEAT" },
+		{static_cast<int>(ETextureWrapMode::MIRROR_CLAMP_TO_EDGE), "MIRROR_CLAMP_TO_EDGE"}
+	};
+
+	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settingsColumns, kHorizontalWrap);
+	auto& horizontalWrap = m_settingsColumns->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>(kHorizontalWrap));
+	horizontalWrap.choices = wrapModes;
+	horizontalWrap.ValueChangedEvent += [this, kHorizontalWrap](int p_choice) {
+		m_metadata->Set(kHorizontalWrap, p_choice);
+	};
+
+	OvCore::Helpers::GUIDrawer::CreateTitle(*m_settingsColumns, kVerticalWrap);
+	auto& verticalWrap = m_settingsColumns->CreateWidget<OvUI::Widgets::Selection::ComboBox>(m_metadata->Get<int>(kVerticalWrap));
+	verticalWrap.choices = wrapModes;
+	verticalWrap.ValueChangedEvent += [this, kVerticalWrap](int p_choice) {
+		m_metadata->Set(kVerticalWrap, p_choice);
 	};
 
 	OvCore::Helpers::GUIDrawer::DrawBoolean(*m_settingsColumns, kEnableMipmapping,
@@ -346,5 +370,5 @@ void OvEditor::Panels::AssetProperties::Apply()
 		}
 	}
 
-    Refresh();
+	Refresh();
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Loaders/TextureLoader.h
@@ -30,12 +30,16 @@ namespace OvRendering::Resources::Loaders
 		* @param p_filePath
 		* @param p_minFilter
 		* @param p_magFilter
+		* @param p_horizontalWrapMode
+		* @param p_verticalWrapMode
 		* @param p_generateMipmap
 		*/
 		static Texture* Create(
 			const std::string& p_filepath,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+			OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 			bool p_generateMipmap
 		);
 
@@ -55,6 +59,8 @@ namespace OvRendering::Resources::Loaders
 		* @param p_height
 		* @param p_minFilter
 		* @param p_magFilter
+		* @param p_horizontalWrapMode
+		* @param p_verticalWrapMode
 		* @param p_generateMipmap
 		*/
 		static Texture* CreateFromMemory(
@@ -63,6 +69,8 @@ namespace OvRendering::Resources::Loaders
 			uint32_t p_height,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+			OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 			bool p_generateMipmap
 		);
 
@@ -72,6 +80,8 @@ namespace OvRendering::Resources::Loaders
 		* @param p_filePath
 		* @param p_minFilter
 		* @param p_magFilter
+		* @param p_horizontalWrapMode
+		* @param p_verticalWrapMode
 		* @param p_generateMipmap
 		*/
 		static void Reload(
@@ -79,6 +89,8 @@ namespace OvRendering::Resources::Loaders
 			const std::string& p_filePath,
 			OvRendering::Settings::ETextureFilteringMode p_minFilter,
 			OvRendering::Settings::ETextureFilteringMode p_magFilter,
+			OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+			OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 			bool p_generateMipmap
 		);
 

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/TextureLoader.cpp
@@ -50,6 +50,8 @@ namespace
 		void* p_data,
 		OvRendering::Settings::ETextureFilteringMode p_minFilter,
 		OvRendering::Settings::ETextureFilteringMode p_magFilter,
+		OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+		OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 		uint32_t p_width,
 		uint32_t p_height,
 		bool p_generateMipmap,
@@ -63,6 +65,8 @@ namespace
 			.height = p_height,
 			.minFilter = p_minFilter,
 			.magFilter = p_magFilter,
+			.horizontalWrap = p_horizontalWrapMode,
+			.verticalWrap = p_verticalWrapMode,
 			.internalFormat = p_hdr ? EInternalFormat::RGBA32F : EInternalFormat::RGBA8,
 			.useMipMaps = p_generateMipmap
 		});
@@ -80,13 +84,28 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 	const std::string& p_filepath,
 	OvRendering::Settings::ETextureFilteringMode p_minFilter,
 	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+	OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 	bool p_generateMipmap
 )
 {
 	if (Image image{ p_filepath })
 	{
 		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filepath));
-		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap, image.isHDR);
+
+		PrepareTexture(
+			*texture,
+			image.data,
+			p_minFilter,
+			p_magFilter,
+			p_horizontalWrapMode,
+			p_verticalWrapMode,
+			image.width,
+			image.height,
+			p_generateMipmap,
+			image.isHDR
+		);
+
 		return new Texture{ p_filepath, std::move(texture) };
 	}
 
@@ -106,6 +125,8 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 		colorData.data(), 1, 1,
 		OvRendering::Settings::ETextureFilteringMode::NEAREST,
 		OvRendering::Settings::ETextureFilteringMode::NEAREST,
+		OvRendering::Settings::ETextureWrapMode::REPEAT,
+		OvRendering::Settings::ETextureWrapMode::REPEAT,
 		false
 	);
 }
@@ -116,11 +137,26 @@ OvRendering::Resources::Texture* OvRendering::Resources::Loaders::TextureLoader:
 	uint32_t p_height,
 	OvRendering::Settings::ETextureFilteringMode p_minFilter,
 	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+	OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 	bool p_generateMipmap
 )
 {
 	auto texture = std::make_unique<HAL::Texture>("FromMemory");
-	PrepareTexture(*texture, p_data, p_minFilter, p_magFilter, p_width, p_height, p_generateMipmap, false);
+
+	PrepareTexture(
+		*texture,
+		p_data,
+		p_minFilter,
+		p_magFilter,
+		p_horizontalWrapMode,
+		p_verticalWrapMode,
+		p_width,
+		p_height,
+		p_generateMipmap,
+		false
+	);
+
 	return new Texture("", std::move(texture));
 }
 
@@ -129,13 +165,28 @@ void OvRendering::Resources::Loaders::TextureLoader::Reload(
 	const std::string& p_filePath,
 	OvRendering::Settings::ETextureFilteringMode p_minFilter,
 	OvRendering::Settings::ETextureFilteringMode p_magFilter,
+	OvRendering::Settings::ETextureWrapMode p_horizontalWrapMode,
+	OvRendering::Settings::ETextureWrapMode p_verticalWrapMode,
 	bool p_generateMipmap
 )
 {
 	if (Image image{ p_filePath })
 	{
 		auto texture = std::make_unique<HAL::Texture>(OvTools::Utils::PathParser::GetElementName(p_filePath));
-		PrepareTexture(*texture, image.data, p_minFilter, p_magFilter, image.width, image.height, p_generateMipmap, image.isHDR);
+
+		PrepareTexture(
+			*texture,
+			image.data,
+			p_minFilter,
+			p_magFilter,
+			p_horizontalWrapMode,
+			p_verticalWrapMode,
+			image.width,
+			image.height,
+			p_generateMipmap,
+			image.isHDR
+		);
+
 		p_texture.SetTexture(std::move(texture));
 	}
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Added an option to tweak texture wrap modes (horizontal & vertical)
* Fixed texture tiling/offset would show a seam when mipmapping was enabled
* Added support for texture coordinates tiling & offset with parallax occlusion mapping

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #(issue number)

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->


https://github.com/user-attachments/assets/3659cfe6-210c-4522-bd35-b68ab88e576d

_Tiling & offset working with parallax_

![image](https://github.com/user-attachments/assets/ddee1d8c-7914-4176-9791-51e561c0f28d)
_Updated texture asset properties_
