### PR TITLE
Added distance fade and alpha dithering

### DIFF
--- a/Resources/Engine/Shaders/Common/Utils.ovfxh
+++ b/Resources/Engine/Shaders/Common/Utils.ovfxh
@@ -19,6 +19,25 @@ bool IsOrthographic(mat4 projectionMatrix)
     return projectionMatrix[3][3] > 0.5;
 }
 
+float DistanceFadeAlpha(vec3 fragPos, vec3 viewPos, float fadeStart, float fadeLength)
+{
+    const float distanceToFragment = length(fragPos - viewPos);
+    const float alphaBasedOnDistance = 1.0 - (distanceToFragment - fadeStart) / fadeLength;
+    return alphaBasedOnDistance;
+}
+
+float Dithering(float alpha, vec2 fragCoord)
+{
+    const mat4 kThresholdMatrix = mat4(
+        1.0 / 17.0,  9.0 / 17.0,  3.0 / 17.0, 11.0 / 17.0,
+        13.0 / 17.0,  5.0 / 17.0, 15.0 / 17.0,  7.0 / 17.0,
+        4.0 / 17.0, 12.0 / 17.0,  2.0 / 17.0, 10.0 / 17.0,
+        16.0 / 17.0,  8.0 / 17.0, 14.0 / 17.0,  6.0 / 17.0
+    );
+
+    return alpha - kThresholdMatrix[int(fragCoord.x) % 4][int(fragCoord.y) % 4];
+}
+
 // Expects a height map with values in the range [0, 1].
 // 1.0 means the height is at the maximum depth, 0.0 means the height is at the minimum depth.
 vec2 ApplyParallaxOcclusionMapping(vec2 texCoords, sampler2D heightMap, vec3 tangentViewPos, vec3 tangentFragPos, float heightScale, int minLayers, int maxLayers)

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -1,7 +1,9 @@
 #feature SHADOW_PASS
 #feature PARALLAX_MAPPING
 #feature ALPHA_CLIPPING
+#feature ALPHA_DITHERING
 #feature NORMAL_MAPPING
+#feature DISTANCE_FADE
 
 #shader vertex
 #version 450 core
@@ -90,6 +92,11 @@ uniform float u_AlphaClippingThreshold = 0.1;
 uniform float u_ShadowClippingThreshold = 0.5;
 #endif
 
+#if defined(DISTANCE_FADE)
+uniform float u_DistanceFadeStart = 100.0;
+uniform float u_DistanceFadeLength = 10.0;
+#endif
+
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
 
@@ -97,6 +104,15 @@ out vec4 FRAGMENT_COLOR;
 
 void main()
 {
+#if defined(DISTANCE_FADE)
+    const float distanceAlpha = DistanceFadeAlpha(fs_in.FragPos, ubo_ViewPos, u_DistanceFadeStart, u_DistanceFadeLength);
+    const float ditheredDistanceAlpha = Dithering(distanceAlpha, gl_FragCoord.xy);
+    if (ditheredDistanceAlpha < 0)
+    {
+        discard;
+    }
+#endif
+
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
@@ -119,6 +135,14 @@ void main()
 
 #if defined(ALPHA_CLIPPING)
     if (diffuse.a < u_AlphaClippingThreshold)
+    {
+        discard;
+    }
+#endif
+
+#if defined(ALPHA_DITHERING)
+    const float ditheredAlpha = Dithering(diffuse.a, gl_FragCoord.xy);
+    if (ditheredAlpha < 0)
     {
         discard;
     }

--- a/Resources/Engine/Shaders/StandardPBR.ovfx
+++ b/Resources/Engine/Shaders/StandardPBR.ovfx
@@ -1,7 +1,9 @@
 #feature SHADOW_PASS
 #feature PARALLAX_MAPPING
 #feature ALPHA_CLIPPING
+#feature ALPHA_DITHERING
 #feature NORMAL_MAPPING
+#feature DISTANCE_FADE
 
 #shader vertex
 #version 450 core
@@ -92,6 +94,11 @@ uniform float u_AlphaClippingThreshold = 0.1;
 uniform float u_ShadowClippingThreshold = 0.5;
 #endif
 
+#if defined(DISTANCE_FADE)
+uniform float u_DistanceFadeStart = 100.0;
+uniform float u_DistanceFadeLength = 10.0;
+#endif
+
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
 
@@ -99,6 +106,15 @@ out vec4 FRAGMENT_COLOR;
 
 void main()
 {
+#if defined(DISTANCE_FADE)
+    const float distanceAlpha = DistanceFadeAlpha(fs_in.FragPos, ubo_ViewPos, u_DistanceFadeStart, u_DistanceFadeLength);
+    const float ditheredDistanceAlpha = Dithering(distanceAlpha, gl_FragCoord.xy);
+    if (ditheredDistanceAlpha < 0)
+    {
+        discard;
+    }
+#endif
+
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
@@ -121,6 +137,14 @@ void main()
 
 #if defined(ALPHA_CLIPPING)
     if (albedo.a < u_AlphaClippingThreshold)
+    {
+        discard;
+    }
+#endif
+
+#if defined(ALPHA_DITHERING)
+    const float ditheredAlpha = Dithering(albedo.a, gl_FragCoord.xy);
+    if (ditheredAlpha < 0)
     {
         discard;
     }

--- a/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Resources/Loaders/ShaderLoader.cpp
@@ -417,6 +417,8 @@ void main()
 	*/
 	ShaderAssembleResult AssembleShader(const ShaderParseResult& p_parseResult)
 	{
+		const auto startTime = std::chrono::high_resolution_clock::now();
+
 		const auto variantCount = (size_t{ 1UL } << p_parseResult.features.size());
 
 		uint32_t failures = 0;
@@ -465,6 +467,8 @@ void main()
 			);
 		}
 
+		const auto endTime = std::chrono::high_resolution_clock::now();
+
 		if (failures > 0)
 		{
 			if (__LOGGING_SETTINGS.summary)
@@ -479,9 +483,10 @@ void main()
 		else if (__LOGGING_SETTINGS.summary)
 		{
 			OVLOG_INFO(std::format(
-				"[Shader Assembling] {}: {} variant(s) assembled.",
+				"[Shader Assembling] {}: {} variant(s) assembled in {} ms.",
 				p_parseResult.inputInfo.name,
-				variantCount
+				variantCount,
+				std::chrono::duration_cast<std::chrono::milliseconds>(endTime - startTime).count()
 			));
 		}
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added new shader features (for Standard and StandardPBR):
* Added distance fade (fade start and length parametrable)
* Added alpha dithering (discard fragments based on the alpha, useful for fake transparency or to refine cutout edges)
* Added shader compilation timings log

These new features bring the variant count from 16 to 64 (2^6).
Compilation of the Standard and StandardPBR shaders is still pretty quick (less than 50ms on my machine).

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

![image](https://github.com/user-attachments/assets/382510db-651d-456f-b2e3-bc986c9f583d)
_New features_

https://github.com/user-attachments/assets/92534633-9481-4902-8a39-509e9aeda93f

_Alpha dithering_

https://github.com/user-attachments/assets/7d5e2c14-f9df-4747-9645-44a28ea0033c

_Distance fade_

![image](https://github.com/user-attachments/assets/506d0a95-6d0f-4c66-b436-e59a2ab3a5f8)
_Shader compilation time_
