### PR TITLE
Fixed broken gizmo depth test for picking

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -47,13 +47,14 @@ OvEditor::Rendering::PickingRenderPass::PickingRenderPass(OvRendering::Core::Com
 
 	/* Light Material */
 	m_lightMaterial.SetShader(EDITOR_CONTEXT(editorResources)->GetShader("Billboard"));
-	m_lightMaterial.SetDepthTest(true);
+	m_lightMaterial.SetDepthTest(false);
 
 	/* Gizmo Pickable Material */
 	m_gizmoPickingMaterial.SetShader(EDITOR_CONTEXT(editorResources)->GetShader("Gizmo"));
 	m_gizmoPickingMaterial.SetGPUInstances(3);
 	m_gizmoPickingMaterial.SetProperty("u_IsBall", false);
 	m_gizmoPickingMaterial.SetProperty("u_IsPickable", true);
+	m_gizmoPickingMaterial.SetDepthTest(true);
 
 	/* Picking Material */
 	m_actorPickingFallbackMaterial.SetShader(EDITOR_CONTEXT(editorResources)->GetShader("PickingFallback"));
@@ -121,6 +122,9 @@ void OvEditor::Rendering::PickingRenderPass::Draw(OvRendering::Data::PipelineSta
 	DrawPickableModels(pso, scene);
 	DrawPickableCameras(pso, scene);
 	DrawPickableLights(pso, scene);
+
+	// Clear depth, gizmos are rendered on top of everything else
+	m_renderer.Clear(false, true, false);
 
 	if (debugSceneDescriptor.selectedActor)
 	{


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Fixed broken gizmo depth test for picking.
Depth test was enabled between gizmos and models, resulting in gizmos not working when visually inside a model.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
*N/A*

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->


https://github.com/user-attachments/assets/6fbd24ab-07a2-4aed-a7d5-f52b7b43cbde

_Before fix_




https://github.com/user-attachments/assets/df2ca664-cc84-472b-a9fa-0db7ec9eda51

_After fix_
