### PR TITLE
Added `IsDrawable` method to properly skip invalid draw calls

### DIFF
--- a/Sources/Overload/OvRendering/include/OvRendering/Core/ABaseRenderer.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Core/ABaseRenderer.h
@@ -104,7 +104,14 @@ namespace OvRendering::Core
 		);
 
 		/**
+		* Returns true if the entity is drawable. Should be used before submitting an entity.
+		* @param p_drawable
+		*/
+		virtual bool IsDrawable(const Entities::Drawable& p_drawable) const;
+
+		/**
 		* Draw a drawable entity
+		* @note Any submitted entity should be drawable (Use IsDrawable before)
 		* @param p_pso
 		* @param p_drawable
 		*/

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/CompositeRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/CompositeRenderer.cpp
@@ -91,6 +91,13 @@ void OvRendering::Core::CompositeRenderer::DrawEntity(
 {
 	ZoneScoped;
 
+	// Ensure the drawable is valid.
+	// If not, skip the draw call and the attached features.
+	if (!IsDrawable(p_drawable))
+	{
+		return;
+	}
+
 	for (const auto& [_, feature] : m_features)
 	{
 		if (feature->IsEnabled())


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Fixed draw call lifecycle by properly skipping invalid draw calls, to avoid features to execute on ill-formatted draw calls.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #527 
