### PR TITLE
Fixed material deserialize didn't reset properties and features properly

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -145,6 +145,8 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 	/* We get the shader with Deserialize method */
 	const auto shader = Serializer::DeserializeShader(p_doc, p_node, "shader");
 
+	m_properties.clear();
+
 	/* We verify that the shader is valid (Not null) */
 	if (shader)
 	{
@@ -209,6 +211,8 @@ void OvCore::Resources::Material::OnDeserialize(tinyxml2::XMLDocument& p_doc, ti
 			}
 		}
 	}
+
+	m_features.clear();
 
 	const auto features = Serializer::DeserializeString(p_doc, p_node, "features");
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Properties and features inside of a material were not properly reloaded in `OnDeserialize()`. Previous content was never removed.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #512 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/e3149f80-d0e3-487c-9aae-dcb96fcbbe34



