### PR TITLE
Added additional CPU/GPU markers for Tracy profiler

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
@@ -4,10 +4,12 @@
 * @licence: MIT
 */
 
+
 #include <OvCore/Global/ServiceLocator.h>
 #include <OvCore/Rendering/PostProcess/AutoExposureEffect.h>
 #include <OvCore/Rendering/FramebufferUtil.h>
 #include <OvCore/ResourceManagement/ShaderManager.h>
+#include <OvRendering/HAL/Profiling.h>
 
 constexpr uint32_t kLuminanceBufferResolution = 1024;
 constexpr uint32_t kExposureBufferResolution = 1;
@@ -51,6 +53,9 @@ void OvCore::Rendering::PostProcess::AutoExposureEffect::Draw(
 	const EffectSettings& p_settings
 )
 {
+	ZoneScoped;
+	TracyGpuZone("AutoExposureEffect");
+
 	const auto& autoExposureSettings = static_cast<const AutoExposureSettings&>(p_settings);
 
 	// Luminance calculation

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/BloomEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/BloomEffect.cpp
@@ -8,6 +8,7 @@
 #include <OvCore/Rendering/FramebufferUtil.h>
 #include <OvCore/Rendering/PostProcess/BloomEffect.h>
 #include <OvCore/ResourceManagement/ShaderManager.h>
+#include <OvRendering/HAL/Profiling.h>
 
 OvCore::Rendering::PostProcess::BloomEffect::BloomEffect(OvRendering::Core::CompositeRenderer& p_renderer) :
 	AEffect(p_renderer),
@@ -46,6 +47,9 @@ void OvCore::Rendering::PostProcess::BloomEffect::Draw(
 	const EffectSettings& p_settings
 )
 {
+	ZoneScoped;
+	TracyGpuZone("BloomEffect");
+
 	const auto& bloomSettings = static_cast<const BloomSettings&>(p_settings);
 
 	// Step 1: Extract bright spots from the source

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/FXAAEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/FXAAEffect.cpp
@@ -4,9 +4,10 @@
 * @licence: MIT
 */
 
-#include <OvCore/Rendering/PostProcess/FXAAEffect.h>
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/Rendering/PostProcess/FXAAEffect.h>
 #include <OvCore/ResourceManagement/ShaderManager.h>
+#include <OvRendering/HAL/Profiling.h>
 
 OvCore::Rendering::PostProcess::FXAAEffect::FXAAEffect(OvRendering::Core::CompositeRenderer& p_renderer) : AEffect(p_renderer)
 {
@@ -20,5 +21,8 @@ void OvCore::Rendering::PostProcess::FXAAEffect::Draw(
 	const EffectSettings& p_settings
 )
 {
+	ZoneScoped;
+	TracyGpuZone("FXAAEffect");
+
 	m_renderer.Blit(p_pso, p_src, p_dst, m_material);
 }

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/TonemappingEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/TonemappingEffect.cpp
@@ -4,9 +4,10 @@
 * @licence: MIT
 */
 
-#include "OvCore/Rendering/PostProcess/TonemappingEffect.h"
 #include <OvCore/Global/ServiceLocator.h>
+#include <OvCore/Rendering/PostProcess/TonemappingEffect.h>
 #include <OvCore/ResourceManagement/ShaderManager.h>
+#include <OvRendering/HAL/Profiling.h>
 
 OvCore::Rendering::PostProcess::TonemappingEffect::TonemappingEffect(OvRendering::Core::CompositeRenderer& p_renderer) : AEffect(p_renderer)
 {
@@ -20,6 +21,9 @@ void OvCore::Rendering::PostProcess::TonemappingEffect::Draw(
 	const EffectSettings& p_settings
 )
 {
+	ZoneScoped;
+	TracyGpuZone("TonemappingEffect");
+
 	const auto& tonemappingSettings = static_cast<const TonemappingSettings&>(p_settings);
 
 	// Tonemapping

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
@@ -28,6 +28,7 @@ OvCore::Rendering::ShadowRenderPass::ShadowRenderPass(OvRendering::Core::Composi
 
 void OvCore::Rendering::ShadowRenderPass::Draw(OvRendering::Data::PipelineState p_pso)
 {
+	ZoneScoped;
 	TracyGpuZone("ShadowRenderPass");
 
 	using namespace OvCore::Rendering;

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -127,6 +127,7 @@ public:
 protected:
 	virtual void Draw(OvRendering::Data::PipelineState p_pso) override
 	{
+		ZoneScoped;
 		TracyGpuZone("DebugCamerasRenderPass");
 
 		using namespace OvRendering::Features;
@@ -187,6 +188,7 @@ public:
 protected:
 	virtual void Draw(OvRendering::Data::PipelineState p_pso) override
 	{
+		ZoneScoped;
 		TracyGpuZone("DebugLightsRenderPass");
 
 		auto& sceneDescriptor = m_renderer.GetDescriptor<OvCore::Rendering::SceneRenderer::SceneDescriptor>();
@@ -237,6 +239,7 @@ protected:
 
 	virtual void Draw(OvRendering::Data::PipelineState p_pso) override
 	{
+		ZoneScoped;
 		TracyGpuZone("DebugActorRenderPass");
 
 		// Clear stencil buffer for outline rendering

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/GridRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/GridRenderPass.cpp
@@ -28,6 +28,7 @@ OvEditor::Rendering::GridRenderPass::GridRenderPass(OvRendering::Core::Composite
 
 void OvEditor::Rendering::GridRenderPass::Draw(OvRendering::Data::PipelineState p_pso)
 {
+	ZoneScoped;
 	TracyGpuZone("GridRenderPass");
 
 	OVASSERT(m_renderer.HasDescriptor<GridDescriptor>(), "Cannot find GridDescriptor attached to this renderer");

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -98,7 +98,7 @@ OvEditor::Rendering::PickingRenderPass::PickingResult OvEditor::Rendering::Picki
 void OvEditor::Rendering::PickingRenderPass::Draw(OvRendering::Data::PipelineState p_pso)
 {
 	// TODO: Make sure we only renderer when the view is hovered and not being resized
-
+	ZoneScoped;
 	TracyGpuZone("PickingRenderPass");
 
 	using namespace OvCore::Rendering;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added additional CPU/GPU markers for Tracy profiler to cover the entire render frame.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs

![image](https://github.com/user-attachments/assets/e2e06515-8cc4-4c63-9dc3-5f1ae3937272)
_The full frame is now marked with CPU/GPU timers_

