### PR TITLE
Added a pass system to shaders

### DIFF
--- a/Resources/Engine/Shaders/Atmosphere.ovfx
+++ b/Resources/Engine/Shaders/Atmosphere.ovfx
@@ -1,5 +1,6 @@
-#feature OUTLINE_PASS
-#feature PICKING_PASS
+#pass OUTLINE_PASS
+#pass PICKING_PASS
+
 #feature DISABLE_TRACKING
 
 #shader vertex

--- a/Resources/Engine/Shaders/Skysphere.ovfx
+++ b/Resources/Engine/Shaders/Skysphere.ovfx
@@ -1,5 +1,5 @@
-#feature OUTLINE_PASS
-#feature PICKING_PASS
+#pass OUTLINE_PASS
+#pass PICKING_PASS
 
 #shader vertex
 #version 450 core

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -1,4 +1,5 @@
-#feature SHADOW_PASS
+#pass SHADOW_PASS
+
 #feature PARALLAX_MAPPING
 #feature ALPHA_CLIPPING
 #feature ALPHA_DITHERING

--- a/Resources/Engine/Shaders/Unlit.ovfx
+++ b/Resources/Engine/Shaders/Unlit.ovfx
@@ -1,4 +1,5 @@
-#feature SHADOW_PASS
+#pass SHADOW_PASS
+
 #feature ALPHA_CLIPPING
 
 #shader vertex

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderPass.cpp
@@ -112,7 +112,7 @@ void OvCore::Rendering::ShadowRenderPass::DrawShadows(
 
 							// If the material has shadow pass, use it, otherwise use the shadow fallback material
 							auto& targetMaterial =
-								material->SupportsFeature(shadowPassName) ?
+								material->HasPass(shadowPassName) ?
 								*material :
 								m_shadowMaterial;
 
@@ -133,7 +133,7 @@ void OvCore::Rendering::ShadowRenderPass::DrawShadows(
 							drawable.stateMask.frontfaceCulling = false;
 							drawable.stateMask.backfaceCulling = false;
 
-							drawable.featureSetOverride = targetMaterial.GetFeatures() + shadowPassName;
+							drawable.pass = shadowPassName;
 
 							drawable.AddDescriptor<EngineDrawableDescriptor>({
 								modelMatrix,

--- a/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Resources/Material.cpp
@@ -38,7 +38,7 @@ void OvCore::Resources::Material::OnSerialize(tinyxml2::XMLDocument& p_doc, tiny
 	tinyxml2::XMLNode* uniformsNode = p_doc.NewElement("uniforms");
 	p_node->InsertEndChild(uniformsNode);
 
-	const auto program = GetProgram();
+	const auto program = GetVariant();
 
 	// If the material has no valid program for the current feature set, we skip serialization of properties.
 	if (!program)

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
@@ -156,7 +156,7 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelToStencil(
 	{
 		auto getStencilMaterial = [&]() -> OvCore::Resources::Material& {
 			auto material = p_materials.has_value() ? p_materials->at(mesh->GetMaterialIndex()) : nullptr;
-			if (material && material->IsValid() && material->SupportsFeature(outlinePassName))
+			if (material && material->IsValid() && material->HasPass(outlinePassName))
 			{
 				return *material;
 			}
@@ -178,7 +178,7 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelToStencil(
 		element.stateMask = stateMask;
 		element.stateMask.depthTest = false;
 		element.stateMask.colorWriting = false;
-		element.featureSetOverride = targetMaterial.GetFeatures() + outlinePassName;
+		element.pass = outlinePassName;
 
 		element.AddDescriptor(engineDrawableDescriptor);
 
@@ -200,7 +200,7 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelOutline(
 	{
 		auto getStencilMaterial = [&]() -> OvCore::Resources::Material& {
 			auto material = p_materials.has_value() ? p_materials->at(mesh->GetMaterialIndex()) : nullptr;
-			if (material && material->IsValid() && material->SupportsFeature(outlinePassName))
+			if (material && material->IsValid() && material->HasPass(outlinePassName))
 			{
 				return *material;
 			}
@@ -227,7 +227,7 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawModelOutline(
 		drawable.material = targetMaterial;
 		drawable.stateMask = stateMask;
 		drawable.stateMask.depthTest = false;
-		drawable.featureSetOverride = targetMaterial.GetFeatures() + outlinePassName;
+		drawable.pass = outlinePassName;
 
 		drawable.AddDescriptor(engineDrawableDescriptor);
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -172,7 +172,7 @@ void OvEditor::Rendering::PickingRenderPass::DrawPickableModels(
 
 						// If the material has picking pass, use it, otherwise use the picking fallback material
 						auto& targetMaterial =
-							(customMaterial && customMaterial->IsValid() && customMaterial->SupportsFeature(pickingPassName)) ?
+							(customMaterial && customMaterial->IsValid() && customMaterial->HasPass(pickingPassName)) ?
 							*customMaterial :
 							m_actorPickingFallbackMaterial;
 
@@ -190,7 +190,7 @@ void OvEditor::Rendering::PickingRenderPass::DrawPickableModels(
 						drawable.stateMask = stateMask;
 						drawable.stateMask.frontfaceCulling = false;
 						drawable.stateMask.backfaceCulling = false;
-						drawable.featureSetOverride = targetMaterial.GetFeatures() + pickingPassName;
+						drawable.pass = pickingPassName;
 
 						drawable.AddDescriptor<OvCore::Rendering::EngineDrawableDescriptor>({
 							modelMatrix

--- a/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Data/Material.h
@@ -62,10 +62,12 @@ namespace OvRendering::Data
 		void SetShader(OvRendering::Resources::Shader* p_shader);
 
 		/**
-		* Returns the shader program (variant) given the current feature set
+		* Returns the variant (shader program) given a pass and the current feature set (or an override)
+		* @param p_pass
 		* @param p_override
 		*/
-		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> GetProgram(
+		OvTools::Utils::OptRef<OvRendering::HAL::ShaderProgram> GetVariant(
+			std::optional<const std::string_view> p_pass = std::nullopt,
 			OvTools::Utils::OptRef<const Data::FeatureSet> p_override = std::nullopt
 		) const;
 
@@ -77,10 +79,12 @@ namespace OvRendering::Data
 		/**
 		* Bind the material and send its uniform data to the GPU
 		* @param p_emptyTexture (The texture to use if a texture uniform is null)
+		* @param p_pass
 		* @param p_featureSetOverride
 		*/
 		void Bind(
 			HAL::Texture* p_emptyTexture = nullptr,
+			std::optional<const std::string_view> p_pass = std::nullopt,
 			OvTools::Utils::OptRef<const Data::FeatureSet> p_featureSetOverride = std::nullopt
 		);
 
@@ -304,6 +308,12 @@ namespace OvRendering::Data
 		* @param p_feature
 		*/
 		bool SupportsFeature(const std::string& p_feature) const;
+
+		/**
+		* Returns true if the material has a pass
+		* @param p_pass
+		*/
+		bool HasPass(const std::string& p_pass) const;
 
 		/**
 		* Returns true if the material supports orthopgraphic projection

--- a/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Entities/Drawable.h
@@ -22,6 +22,7 @@ namespace OvRendering::Entities
 		OvTools::Utils::OptRef<OvRendering::Data::Material> material;
 		Data::StateMask stateMask;
 		Settings::EPrimitiveMode primitiveMode = OvRendering::Settings::EPrimitiveMode::TRIANGLES;
+		std::optional<std::string> pass = std::nullopt;
 		std::optional<Data::FeatureSet> featureSetOverride = std::nullopt;
 	};
 }

--- a/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Resources/Shader.h
@@ -27,18 +27,29 @@ namespace OvRendering::Resources
 		friend class Loaders::ShaderLoader;
 
 	public:
-		using ProgramVariants = std::unordered_map<
+		// Shader programs for each feature combination
+		using FeatureVariants = std::unordered_map<
 			Data::FeatureSet,
 			std::unique_ptr<HAL::ShaderProgram>,
 			Data::FeatureSetHash,
 			Data::FeatureSetEqual
 		>;
 
+		// Shader programs for each pass for each feature combination
+		using Variants = std::unordered_map<
+			std::string,
+			FeatureVariants
+		>;
+
 		/**
 		* Returns the associated shader program for a given feature set
+		* @param p_pass (optional) The pass to use. If not provided, the default pass will be selected.
 		* @param p_featureSet (optional) The feature set to use. If not provided, the default program will be used.
 		*/
-		HAL::ShaderProgram& GetProgram(const Data::FeatureSet& p_featureSet = {});
+		HAL::ShaderProgram& GetVariant(
+			std::optional<const std::string_view> p_pass = std::nullopt,
+			const Data::FeatureSet& p_featureSet = {}
+		);
 
 		/**
 		* Returns supported features
@@ -46,24 +57,30 @@ namespace OvRendering::Resources
 		const Data::FeatureSet& GetFeatures() const;
 
 		/**
+		* Returns supported passes
+		*/
+		const std::unordered_set<std::string>& GetPasses() const;
+
+		/**
 		* Return all programs
 		*/
-		const ProgramVariants& GetPrograms() const;
+		const Variants& GetVariants() const;
 
 	private:
 		Shader(
 			const std::string p_path,
-			ProgramVariants&& p_programs
+			Variants&& p_variants
 		);
 
 		~Shader() = default;
-		void SetPrograms(ProgramVariants&& p_programs);
+		void SetVariants(Variants&& p_variants);
 
 	public:
 		const std::string path;
 
 	private:
+		std::unordered_set<std::string> m_passes;
 		Data::FeatureSet m_features;
-		ProgramVariants m_programs;
+		Variants m_variants;
 	};
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/ABaseRenderer.cpp
@@ -219,6 +219,7 @@ void OvRendering::Core::ABaseRenderer::DrawEntity(
 
 	p_drawable.material->Bind(
 		&m_emptyTexture->GetTexture(),
+		p_drawable.pass,
 		p_drawable.featureSetOverride.has_value() ?
 		OvTools::Utils::OptRef<const Data::FeatureSet>(p_drawable.featureSetOverride.value()) :
 		std::nullopt

--- a/Sources/Overload/OvRendering/src/OvRendering/Features/DebugShapeRenderFeature.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Features/DebugShapeRenderFeature.cpp
@@ -109,7 +109,7 @@ void OvRendering::Features::DebugShapeRenderFeature::DrawLine(
 
 	m_renderer.DrawEntity(p_pso, drawable);
 
-	m_lineShader->GetProgram().Unbind();
+	m_lineShader->GetVariant().Unbind();
 }
 
 void OvRendering::Features::DebugShapeRenderFeature::DrawBox(

--- a/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/HAL/OpenGL/GLBackend.cpp
@@ -221,7 +221,6 @@ namespace OvRendering::HAL
 			return std::nullopt;
 		}
 
-		OVLOG_INFO(std::format("OpenGL initialized: {}.{}", GL_MAJOR_VERSION, GL_MINOR_VERSION));
 		TracyGpuContext;
 
 		if (debug)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added a new system to define shader passes:
* to avoid unnecessary variants (only one pass can be used at a time)
* to simplify pass selection for each drawable (instead of having to override a material feature set, the pass to use can be specified)
* to allow the material editor to differentiate properties that are pass-specific and feature-specific (all pass-specific properties should be shown)

This allows custom passes to expose settings through the material editor.

Updated shaders to use the new pass system.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes https://github.com/Overload-Technologies/Overload/issues/543

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
![image](https://github.com/user-attachments/assets/efb2cfce-92ee-41a1-a97d-fce8eb459c1f)
_Shadow Clipping Threshold property now showing properly_

