### PR TITLE
[WIP] Added a debug view system

### DIFF
--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -136,9 +136,14 @@ void main()
     }
 #endif
 
-#if defined(DEPTH_PASS)
-    FRAGMENT_COLOR = vec4(gl_FragCoord.zzz, 1.0);
-    return;
+#if defined(DEPTH_PASS)  
+    const float near = 0.1;
+    const float far = 50.0;
+    const float depth = gl_FragCoord.z;
+    const float z = depth * 2.0 - 1.0; // back to NDC 
+    float linearDepth = (2.0 * near * far) / (far + near - z * (far - near)) / far;
+    FRAGMENT_COLOR = vec4(vec3(linearDepth), 1.0);
+    return;  
 #endif
 
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -1,4 +1,11 @@
 #pass SHADOW_PASS
+#pass ALBEDO_PASS
+#pass METALLIC_PASS
+#pass ROUGHNESS_PASS
+#pass AO_PASS
+#pass NORMAL_PASS
+#pass UV_PASS
+#pass DEPTH_PASS
 
 #feature PARALLAX_MAPPING
 #feature ALPHA_CLIPPING
@@ -129,6 +136,11 @@ void main()
     }
 #endif
 
+#if defined(DEPTH_PASS)
+    FRAGMENT_COLOR = vec4(gl_FragCoord.zzz, 1.0);
+    return;
+#endif
+
     vec2 texCoords = TileAndOffsetTexCoords(fs_in.TexCoords, u_TextureTiling, u_TextureOffset);
 
 #if defined(PARALLAX_MAPPING)
@@ -170,6 +182,18 @@ void main()
     const vec3 normal = normalize(fs_in.Normal);
 #endif
 
+#if defined(NORMAL_PASS)
+    FRAGMENT_COLOR = vec4((normal + 1.0) / 2.0, 1.0);
+    return;
+#endif
+
+    const float ao = texture(u_AmbientOcclusionMap, texCoords).r;
+
+#if defined(AO_PASS)
+    FRAGMENT_COLOR = vec4(ao.rrr, 1.0);
+    return;
+#endif
+
 #if defined(SPECULAR_WORKFLOW)
     const float specular = texture(u_SpecularMap, texCoords).r * u_Specular;
     const float glossiness = texture(u_GlossinessMap, texCoords).r * u_Glossiness;
@@ -180,7 +204,25 @@ void main()
     const float roughness = texture(u_RoughnessMap, texCoords).r * u_Roughness;
 #endif
 
-    const float ao = texture(u_AmbientOcclusionMap, texCoords).r;
+#if defined(ALBEDO_PASS)
+    FRAGMENT_COLOR = vec4(albedo.rgba);
+    return;
+#endif
+
+#if defined(METALLIC_PASS)
+    FRAGMENT_COLOR = vec4(metallic.rrr, 1.0);
+    return;
+#endif
+
+#if defined(ROUGHNESS_PASS)
+    FRAGMENT_COLOR = vec4(roughness.rrr, 1.0);
+    return;
+#endif
+
+#if defined(UV_PASS)
+    FRAGMENT_COLOR = vec4(texCoords.x, texCoords.y, 0.0, 1.0);
+    return;
+#endif
 
     vec3 pbr = PBRLightingModel(
         albedo.rgb,

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/EngineBufferRenderFeature.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/EngineBufferRenderFeature.h
@@ -37,7 +37,7 @@ namespace OvCore::Rendering
 	protected:
 		virtual void OnBeginFrame(const OvRendering::Data::FrameDescriptor& p_frameDescriptor) override;
 		virtual void OnEndFrame() override;
-		virtual void OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, const OvRendering::Entities::Drawable& p_drawable) override;
+		virtual void OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, OvRendering::Entities::Drawable& p_drawable) override;
 
 	protected:
 		std::chrono::high_resolution_clock::time_point m_startTime;

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/ShadowRenderFeature.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/ShadowRenderFeature.h
@@ -32,7 +32,7 @@ namespace OvCore::Rendering
 		ShadowRenderFeature(OvRendering::Core::CompositeRenderer& p_renderer);
 
 	protected:
-		virtual void OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, const OvRendering::Entities::Drawable& p_drawable);
+		virtual void OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, OvRendering::Entities::Drawable& p_drawable);
 		virtual void OnAfterDraw(OvRendering::Data::PipelineState& p_pso, const OvRendering::Entities::Drawable& p_drawable);
 	};
 }

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/EngineBufferRenderFeature.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/EngineBufferRenderFeature.cpp
@@ -80,7 +80,7 @@ void OvCore::Rendering::EngineBufferRenderFeature::OnEndFrame()
 	m_engineBuffer->Unbind();
 }
 
-void OvCore::Rendering::EngineBufferRenderFeature::OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, const OvRendering::Entities::Drawable& p_drawable)
+void OvCore::Rendering::EngineBufferRenderFeature::OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, OvRendering::Entities::Drawable& p_drawable)
 {
 	OvTools::Utils::OptRef<const EngineDrawableDescriptor> descriptor;
 

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/ShadowRenderFeature.cpp
@@ -19,7 +19,7 @@ OvCore::Rendering::ShadowRenderFeature::ShadowRenderFeature(OvRendering::Core::C
 {
 }
 
-void OvCore::Rendering::ShadowRenderFeature::OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, const OvRendering::Entities::Drawable& p_drawable)
+void OvCore::Rendering::ShadowRenderFeature::OnBeforeDraw(OvRendering::Data::PipelineState& p_pso, OvRendering::Entities::Drawable& p_drawable)
 {
 	auto& material = p_drawable.material.value();
 

--- a/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/EditorActions.h
@@ -23,6 +23,11 @@ namespace tinyxml2
 	class XMLDocument;
 }
 
+namespace OvEditor::Rendering
+{
+	enum class EDebugViewMode;
+}
+
 namespace OvEditor::Core
 {
 	enum class EGizmoOperation;
@@ -162,6 +167,12 @@ namespace OvEditor::Core
 		* Returns the current gizmo operation
 		*/
 		EGizmoOperation GetGizmoOperation() const;
+
+		/**
+		* Sets the debug view mode to use
+		* @param p_mode
+		*/
+		void SetSceneViewDebugMode(OvEditor::Rendering::EDebugViewMode p_mode);
 		#pragma endregion
 
 		#pragma region ACTOR_CREATION_DESTRUCTION

--- a/Sources/Overload/OvEditor/include/OvEditor/Rendering/DebugSceneRenderer.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Rendering/DebugSceneRenderer.h
@@ -24,6 +24,19 @@ namespace OvEditor::Panels { class AView; }
 
 namespace OvEditor::Rendering
 {
+	enum class EDebugViewMode
+	{
+		NONE,
+		ALBEDO,
+		METALLIC,
+		ROUGHNESS,
+		AO,
+		NORMAL,
+		UV,
+		DEPTH,
+		WIREFRAME
+	};
+
 	/**
 	* Provide a debug layer on top of the default scene renderer to see "invisible" entities such as
 	* lights, cameras, 
@@ -44,5 +57,11 @@ namespace OvEditor::Rendering
 		* @param p_driver
 		*/
 		DebugSceneRenderer(OvRendering::Context::Driver& p_driver);
+
+		/**
+		* Set a debug view mode
+		* @param p_mode
+		*/
+		void SetDebugViewMode(EDebugViewMode p_mode) const;
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/EditorActions.cpp
@@ -27,6 +27,7 @@
 #include <OvEditor/Panels/MaterialEditor.h>
 #include <OvEditor/Panels/ProjectSettings.h>
 #include <OvEditor/Panels/SceneView.h>
+#include <OvEditor/Rendering/DebugSceneRenderer.h>
 
 #include <OvTools/Utils/PathParser.h>
 #include <OvTools/Utils/String.h>
@@ -501,6 +502,13 @@ OvEditor::Core::EGizmoOperation OvEditor::Core::EditorActions::GetGizmoOperation
 {
 	auto& sceneView = m_panelsManager.GetPanelAs<OvEditor::Panels::SceneView>("Scene View");
 	return sceneView.GetGizmoOperation();
+}
+
+void OvEditor::Core::EditorActions::SetSceneViewDebugMode(OvEditor::Rendering::EDebugViewMode p_mode)
+{
+	auto& sceneView = m_panelsManager.GetPanelAs<OvEditor::Panels::SceneView>("Scene View");
+	const auto& debugSceneRenderer = static_cast<const OvEditor::Rendering::DebugSceneRenderer&>(sceneView.GetRenderer());
+	debugSceneRenderer.SetDebugViewMode(p_mode);
 }
 
 OvMaths::FVector3 OvEditor::Core::EditorActions::CalculateActorSpawnPoint(float p_distanceToCamera)

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/Toolbar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/Toolbar.cpp
@@ -10,8 +10,10 @@
 #include <OvEditor/Core/EditorActions.h>
 #include <OvEditor/Core/GizmoBehaviour.h>
 #include <OvEditor/Panels/Toolbar.h>
+#include <OvEditor/Rendering/DebugSceneRenderer.h>
 
 #include <OvUI/Widgets/Layout/Spacing.h>
+#include <OvUI/Widgets/Selection/ComboBox.h>
 
 namespace
 {
@@ -91,6 +93,25 @@ OvEditor::Panels::Toolbar::Toolbar
 	};
 
 	EDITOR_EXEC(SetEditorMode(OvEditor::Core::EditorActions::EEditorMode::EDIT));
+
+	using enum OvEditor::Rendering::EDebugViewMode;
+	auto& debugViewSelector = CreateWidget<OvUI::Widgets::Selection::ComboBox>();
+	debugViewSelector.lineBreak = false;
+	debugViewSelector.choices = {
+		{ static_cast<int>(NONE), "Default" },
+		{ static_cast<int>(ALBEDO), "Albedo" },
+		{ static_cast<int>(METALLIC), "Metallic" },
+		{ static_cast<int>(ROUGHNESS), "Roughness" },
+		{ static_cast<int>(AO), "Ambient Occlusion" },
+		{ static_cast<int>(NORMAL), "Normal"},
+		{ static_cast<int>(UV), "UV"},
+		{ static_cast<int>(DEPTH), "Depth"},
+		{ static_cast<int>(WIREFRAME), "Wireframe"}
+	};
+	debugViewSelector.currentChoice = 0;
+	debugViewSelector.ValueChangedEvent += [](int choice) {
+		EDITOR_EXEC(SetSceneViewDebugMode(static_cast<OvEditor::Rendering::EDebugViewMode>(choice)));
+	};
 }
 
 void OvEditor::Panels::Toolbar::_Draw_Impl()

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -131,7 +131,6 @@ protected:
 			if (m_debugViewMode == OvEditor::Rendering::EDebugViewMode::WIREFRAME)
 			{
 				p_pso.rasterizationMode = OvRendering::Settings::ERasterizationMode::LINE;
-				p_pso.depthTest = false;
 			}
 			else
 			{

--- a/Sources/Overload/OvRendering/include/OvRendering/Features/ARenderFeature.h
+++ b/Sources/Overload/OvRendering/include/OvRendering/Features/ARenderFeature.h
@@ -59,7 +59,7 @@ namespace OvRendering::Features
 		* Invoked before drawing a drawable entity
 		* @param p_drawable
 		*/
-		virtual void OnBeforeDraw(Data::PipelineState& p_pso, const Entities::Drawable& p_drawable);
+		virtual void OnBeforeDraw(Data::PipelineState& p_pso, Entities::Drawable& p_drawable);
 
 		/**
 		* Invoked after drawing a drawable entity

--- a/Sources/Overload/OvRendering/src/OvRendering/Core/CompositeRenderer.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Core/CompositeRenderer.cpp
@@ -91,6 +91,8 @@ void OvRendering::Core::CompositeRenderer::DrawEntity(
 {
 	ZoneScoped;
 
+	Entities::Drawable drawable = p_drawable;
+
 	// Ensure the drawable is valid.
 	// If not, skip the draw call and the attached features.
 	if (!IsDrawable(p_drawable))
@@ -102,17 +104,17 @@ void OvRendering::Core::CompositeRenderer::DrawEntity(
 	{
 		if (feature->IsEnabled())
 		{
-			feature->OnBeforeDraw(p_pso, p_drawable);
+			feature->OnBeforeDraw(p_pso, drawable);
 		}
 	}
 
-	ABaseRenderer::DrawEntity(p_pso, p_drawable);
+	ABaseRenderer::DrawEntity(p_pso, drawable);
 	
 	for (const auto& [_, feature] : m_features)
 	{
 		if (feature->IsEnabled())
 		{
-			feature->OnAfterDraw(p_drawable);
+			feature->OnAfterDraw(drawable);
 		}
 	}
 }

--- a/Sources/Overload/OvRendering/src/OvRendering/Features/ARenderFeature.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Features/ARenderFeature.cpp
@@ -32,7 +32,7 @@ void OvRendering::Features::ARenderFeature::OnEndFrame()
 {
 }
 
-void OvRendering::Features::ARenderFeature::OnBeforeDraw(Data::PipelineState& p_pso, const Entities::Drawable& p_drawable)
+void OvRendering::Features::ARenderFeature::OnBeforeDraw(Data::PipelineState& p_pso, Entities::Drawable& p_drawable)
 {
 }
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Added a debug view system, including:
  * Albedo
  * Metallic
  * Roughness
  * AO
  * Normal
  * UV
  * Depth
  * Wireframe

Each debug view only applies to shaders declaring the associated pass (`ALBEDO_PASS`, `METALLIC_PASS`, etc.), except for the wireframe one, that can apply to virtually anything.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #148 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/3873e371-c5c0-40b8-97ea-e45115bac4e9

