### PR TITLE
Various fixes and cleanup for post-process pass

### DIFF
--- a/Resources/Engine/Shaders/PostProcess/Bloom.ovfx
+++ b/Resources/Engine/Shaders/PostProcess/Bloom.ovfx
@@ -16,7 +16,7 @@ void main()
 #version 450 core
 
 in vec2 TexCoords;
-out vec3 FRAGMENT_COLOR;
+out vec4 FRAGMENT_COLOR;
 
 uniform sampler2D _InputTexture;
 uniform sampler2D _BloomTexture;
@@ -26,5 +26,5 @@ void main()
 {
     const vec3 hdrColor = texture(_InputTexture, TexCoords).rgb;
     const vec3 bloomColor = texture(_BloomTexture, TexCoords).rgb;
-    FRAGMENT_COLOR = mix(hdrColor, bloomColor, _BloomStrength);
+    FRAGMENT_COLOR = vec4(mix(hdrColor, bloomColor, _BloomStrength), 1.0);
 }

--- a/Resources/Engine/Shaders/PostProcess/BloomDownsampling.ovfx
+++ b/Resources/Engine/Shaders/PostProcess/BloomDownsampling.ovfx
@@ -18,7 +18,7 @@ void main()
 #version 450 core
 
 in vec2 TexCoords;
-out vec3 downsample;
+out vec4 FRAGMENT_COLOR;
 
 uniform sampler2D _InputTexture;
 uniform vec2 _InputResolution;
@@ -88,6 +88,8 @@ void main()
     // to effectively yield this sum. We get:
     // 0.125*5 + 0.03125*4 + 0.0625*4 = 1
 
+    vec3 downsample = vec3(0.0);
+
     // Check if we need to perform Karis average on each block of 4 samples
 #if defined(KARIS_AVERAGE)
     vec3 groups[5];
@@ -112,4 +114,6 @@ void main()
     downsample += (b+d+f+h)*0.0625;      // ok
     downsample += (j+k+l+m)*0.125;       // ok
 #endif
+
+    FRAGMENT_COLOR = vec4(downsample, 1.0);
 }

--- a/Resources/Engine/Shaders/PostProcess/BloomUpsampling.ovfx
+++ b/Resources/Engine/Shaders/PostProcess/BloomUpsampling.ovfx
@@ -16,7 +16,7 @@ void main()
 #version 450 core
 
 in vec2 TexCoords;
-out vec3 upsample;
+out vec4 FRAGMENT_COLOR;
 
 uniform sampler2D _InputTexture;
 uniform float _FilterRadius;
@@ -47,8 +47,10 @@ void main()
     //  1   | 1 2 1 |
     // -- * | 2 4 2 |
     // 16   | 1 2 1 |
-    upsample = e*4.0;
+    vec3 upsample = e*4.0;
     upsample += (b+d+f+h)*2.0;
     upsample += (a+c+g+i);
     upsample *= 1.0 / 16.0;
+
+    FRAGMENT_COLOR = vec4(upsample, 1.0);
 }

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcess/AutoExposureEffect.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcess/AutoExposureEffect.h
@@ -8,6 +8,7 @@
 
 #include <chrono>
 
+#include <OvCore/Rendering/PingPongFramebuffer.h>
 #include <OvCore/Rendering/PostProcess/AEffect.h>
 #include <OvRendering/Data/Material.h>
 
@@ -57,8 +58,7 @@ namespace OvCore::Rendering::PostProcess
 	private:
 		std::optional<std::chrono::high_resolution_clock::time_point> m_previousTime;
 		OvRendering::HAL::Framebuffer m_luminanceBuffer;
-		std::array<OvRendering::HAL::Framebuffer, 2> m_exposurePingPongBuffer;
-		uint8_t m_exposurePingPongIndex = 0;
+		PingPongFramebuffer m_exposurePingPongBuffer;
 		OvRendering::Data::Material m_luminanceMaterial;
 		OvRendering::Data::Material m_exposureMaterial;
 		OvRendering::Data::Material m_compensationMaterial;

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcess/BloomEffect.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcess/BloomEffect.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <OvCore/Rendering/PingPongFramebuffer.h>
 #include <OvCore/Rendering/PostProcess/AEffect.h>
 #include <OvRendering/Data/Material.h>
 #include <OvRendering/HAL/Framebuffer.h>

--- a/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcessRenderPass.h
+++ b/Sources/Overload/OvCore/include/OvCore/Rendering/PostProcessRenderPass.h
@@ -8,6 +8,7 @@
 
 #include <OvRendering/Core/ARenderPass.h>
 #include <OvRendering/HAL/Framebuffer.h>
+#include <OvCore/Rendering/PingPongFramebuffer.h>
 #include <OvCore/Rendering/PostProcess/AEffect.h>
 
 namespace OvCore::Rendering
@@ -30,6 +31,6 @@ namespace OvCore::Rendering
 	private:
 		OvRendering::Data::Material m_blitMaterial;
 		std::vector<std::unique_ptr<PostProcess::AEffect>> m_effects;
-		std::array<OvRendering::HAL::Framebuffer, 2> m_pingPongBuffers;
+		PingPongFramebuffer m_pingPongBuffers;
 	};
 }

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CPostProcessStack.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CPostProcessStack.cpp
@@ -81,21 +81,21 @@ void OvCore::ECS::Components::CPostProcessStack::OnInspector(OvUI::Internal::Wid
 	auto& fxaaSettings = m_settings.Get<Rendering::PostProcess::FXAAEffect, Rendering::PostProcess::FXAASettings>();
 	auto& tonemappingSettings = m_settings.Get<Rendering::PostProcess::TonemappingEffect, Rendering::PostProcess::TonemappingSettings>();
 
-	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Bloom Enabled", bloomSettings.enabled);
-	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Bloom Intensity", bloomSettings.intensity, 0.1f, 0.0f, Rendering::PostProcess::BloomConstants::kMaxBloomIntensity);
-	OvCore::Helpers::GUIDrawer::DrawScalar<int>(p_root, "Bloom Passes", bloomSettings.passes, 1, Rendering::PostProcess::BloomConstants::kMinPassCount, Rendering::PostProcess::BloomConstants::kMaxPassCount);
-	
-	p_root.CreateWidget<OvUI::Widgets::Visual::Separator>();
-	p_root.CreateWidget<OvUI::Widgets::Layout::Spacing>();
-
 	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Auto Exposure Enabled", autoExposureSettings.enabled);
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Center Weight Bias", autoExposureSettings.centerWeightBias, 0.1f, 0.0f, 1.0f);
-	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Min Luminance (EV)", autoExposureSettings.minLuminanceEV, 1.0f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
-	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Max Luminance (EV)", autoExposureSettings.maxLuminanceEV, 1.0f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
-	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Exposure Compensation (EV)", autoExposureSettings.exposureCompensationEV, 1.0f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
+	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Min Luminance (EV)", autoExposureSettings.minLuminanceEV, 0.1f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
+	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Max Luminance (EV)", autoExposureSettings.maxLuminanceEV, 0.1f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
+	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Exposure Compensation (EV)", autoExposureSettings.exposureCompensationEV, 0.1f, OvCore::Helpers::GUIDrawer::_MIN_FLOAT, OvCore::Helpers::GUIDrawer::_MAX_FLOAT);
 	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Auto Exposure Progressive", autoExposureSettings.progressive);
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Speed Up", autoExposureSettings.speedUp);
 	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Auto Exposure Speed Down", autoExposureSettings.speedDown);
+
+	p_root.CreateWidget<OvUI::Widgets::Visual::Separator>();
+	p_root.CreateWidget<OvUI::Widgets::Layout::Spacing>();
+
+	OvCore::Helpers::GUIDrawer::DrawBoolean(p_root, "Bloom Enabled", bloomSettings.enabled);
+	OvCore::Helpers::GUIDrawer::DrawScalar<float>(p_root, "Bloom Intensity", bloomSettings.intensity, 0.1f, 0.0f, Rendering::PostProcess::BloomConstants::kMaxBloomIntensity);
+	OvCore::Helpers::GUIDrawer::DrawScalar<int>(p_root, "Bloom Passes", bloomSettings.passes, 1, Rendering::PostProcess::BloomConstants::kMinPassCount, Rendering::PostProcess::BloomConstants::kMaxPassCount);
 
 	p_root.CreateWidget<OvUI::Widgets::Visual::Separator>();
 	p_root.CreateWidget<OvUI::Widgets::Layout::Spacing>();
@@ -112,8 +112,7 @@ void OvCore::ECS::Components::CPostProcessStack::OnInspector(OvUI::Internal::Wid
 		{ 4, "Uncharted 2 (Filmic)" },
 		{ 5, "ACES" }
 	};
-	tonemappingMode.ValueChangedEvent += [this](int p_choice)
-	{
+	tonemappingMode.ValueChangedEvent += [this](int p_choice) {
 		auto& tonemappingSettings = m_settings.Get<Rendering::PostProcess::TonemappingEffect, Rendering::PostProcess::TonemappingSettings>();
 		tonemappingSettings.mode = static_cast<OvCore::Rendering::PostProcess::ETonemappingMode>(p_choice);
 	};

--- a/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/Rendering/PostProcess/AutoExposureEffect.cpp
@@ -18,12 +18,9 @@ OvCore::Rendering::PostProcess::AutoExposureEffect::AutoExposureEffect(
 	OvRendering::Core::CompositeRenderer& p_renderer
 ) :	AEffect(p_renderer),
 	m_luminanceBuffer{ "Luminance" },
-	m_exposurePingPongBuffer{
-		OvRendering::HAL::Framebuffer{"ExposurePingPong0"},
-		OvRendering::HAL::Framebuffer{"ExposurePingPong1"}
-	}
+	m_exposurePingPongBuffer{ "Exposure" }
 {
-	for (auto& buffer : m_exposurePingPongBuffer)
+	for (auto& buffer : m_exposurePingPongBuffer.GetFramebuffers())
 	{
 		FramebufferUtil::SetupFramebuffer(
 			buffer,
@@ -76,9 +73,9 @@ void OvCore::Rendering::PostProcess::AutoExposureEffect::Draw(
 	}
 	m_previousTime = currentTime;
 
-	auto& previousExposure = m_exposurePingPongBuffer[(m_exposurePingPongIndex + 1) % 2];
-	auto& currentExposure = m_exposurePingPongBuffer[m_exposurePingPongIndex];
-	m_exposurePingPongIndex = (m_exposurePingPongIndex + 1) % 2;
+	auto& previousExposure = m_exposurePingPongBuffer[0];
+	auto& currentExposure = m_exposurePingPongBuffer[1];
+	++m_exposurePingPongBuffer;
 
 	// Exposure adaptation
 	m_exposureMaterial.SetProperty("_LuminanceTexture", &luminanceTex.value(), true);

--- a/Sources/Overload/OvRendering/src/OvRendering/Context/Driver.cpp
+++ b/Sources/Overload/OvRendering/src/OvRendering/Context/Driver.cpp
@@ -51,6 +51,10 @@ OvRendering::Context::Driver::~Driver()
 void OvRendering::Context::Driver::OnFrameCompleted()
 {
 	m_gfxBackend->OnFrameCompleted();
+
+	// Prevents state leak between frames, and especially useful when external code (like ImGui)
+	// requires a "neutral" pipeline state.
+	ResetPipelineState();
 }
 
 void OvRendering::Context::Driver::SetViewport(uint32_t p_x, uint32_t p_y, uint32_t p_width, uint32_t p_height)


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Bloom pass now outputs an alpha of `1.0f`, preventing the post-process pass to finish with a framebuffer with alpha `0.0f` if only bloom is enabled (resulting in the editor view displaying a transparent scene output)
* Updated auto-exposure effect and post-process pass to use the `PingPongFramebuffer`
* Re-ordered post-process stack component inspector settings to match pass order (auto-exposure --> bloom --> tonemapping --> FXAA)
* Fixed potential state leak between frames (pipeline state wasn't reset after the frame was completed)

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.
