### PR TITLE
Reduced standard shader variant count from 256 to 32

### DIFF
--- a/Resources/Engine/Shaders/PostProcess/Luminance.ovfx
+++ b/Resources/Engine/Shaders/PostProcess/Luminance.ovfx
@@ -21,7 +21,7 @@ out vec4 FRAGMENT_COLOR;
 uniform sampler2D _InputTexture;
 uniform float _CenterWeightBias;
 
-const float EPSILON = 0.0001f;
+const float EPSILON = 0.0001;
 
 float luminance(vec3 v)
 {

--- a/Resources/Engine/Shaders/PostProcess/Tonemapping.ovfx
+++ b/Resources/Engine/Shaders/PostProcess/Tonemapping.ovfx
@@ -23,9 +23,11 @@ uniform float _Exposure;
 uniform int _Mode;
 uniform int _GammaCorrection;
 
+const float EPSILON = 0.0001;
+
 float luminance(vec3 v)
 {
-    return dot(v, vec3(0.2126, 0.7152, 0.0722));
+    return max(dot(v, vec3(0.2126, 0.7152, 0.0722)), EPSILON);
 }
 
 vec3 applyGammaCorrection(vec3 color)
@@ -62,18 +64,18 @@ vec3 reinhard(vec3 v)
 vec3 reinhard_jodie(vec3 v)
 {
     float l = luminance(v);
-    vec3 tv = v / (1.0f + v);
-    return mix(v / (1.0f + l), tv, tv);
+    vec3 tv = v / (1.0 + v);
+    return mix(v / (1.0 + l), tv, tv);
 }
 
 vec3 uncharted2_tonemap_partial(vec3 x)
 {
-    const float A = 0.15f;
-    const float B = 0.50f;
-    const float C = 0.10f;
-    const float D = 0.20f;
-    const float E = 0.02f;
-    const float F = 0.30f;
+    const float A = 0.15;
+    const float B = 0.50;
+    const float C = 0.10;
+    const float D = 0.20;
+    const float E = 0.02;
+    const float F = 0.30;
     return ((x*(A*x+C*B)+D*E)/(x*(A*x+B)+D*F))-E/F;
 }
 

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -1,12 +1,9 @@
 #pass SHADOW_PASS
 
 #feature PARALLAX_MAPPING
-#feature ALPHA_CLIPPING
-#feature ALPHA_DITHERING
 #feature NORMAL_MAPPING
 #feature DISTANCE_FADE
 #feature SPECULAR_WORKFLOW
-#feature GAMMA_CORRECTION
 
 #shader vertex
 #version 450 core
@@ -96,10 +93,6 @@ uniform int u_MinLayers = 8;
 uniform int u_MaxLayers = 64;
 #endif
 
-#if defined(ALPHA_CLIPPING)
-uniform float u_AlphaClippingThreshold = 0.1;
-#endif
-
 #if defined(SHADOW_PASS)
 #undef PARALLAX_MAPPING // Disable parallax mapping in shadow pass
 uniform float u_ShadowClippingThreshold = 0.5;
@@ -112,6 +105,13 @@ uniform float u_DistanceFadeLength = 10.0;
 
 uniform vec2 u_TextureTiling = vec2(1.0, 1.0);
 uniform vec2 u_TextureOffset = vec2(0.0, 0.0);
+
+uniform float u_AlphaClippingThreshold = 0.0;
+uniform bool u_AlphaDithering = false;
+
+// Useful when no post-processing is applied.
+uniform bool u_BuiltInToneMapping = false;
+uniform bool u_BuiltInGammaCorrection = false;
 
 uniform sampler2D _ShadowMap;
 uniform mat4 _LightSpaceMatrix;
@@ -149,20 +149,15 @@ void main()
     }
 #else
 
-#if defined(ALPHA_CLIPPING)
     if (albedo.a < u_AlphaClippingThreshold)
     {
         discard;
     }
-#endif
 
-#if defined(ALPHA_DITHERING)
-    const float ditheredAlpha = Dithering(albedo.a, gl_FragCoord.xy);
-    if (ditheredAlpha < 0)
+    if (u_AlphaDithering && Dithering(albedo.a, gl_FragCoord.xy) < 0)
     {
         discard;
     }
-#endif
 
 #if defined(NORMAL_MAPPING)
     const vec3 normal = ComputeNormal(texCoords, fs_in.Normal, u_NormalMap, fs_in.TBN);
@@ -194,9 +189,11 @@ void main()
         _LightSpaceMatrix
     );
 
-#if defined(GAMMA_CORRECTION)
-    pbr = pow(pbr, vec3(1.0 / 2.2));
-#endif
+    // Simple built-in tonemapping (Reinhard) and gamma correction for elements
+    // not affected by post-processing (e.g. debug, UI, etc.), but still aiming
+    // to approximate the final PBR look.
+    pbr = mix(pbr, pbr / (pbr + vec3(1.0)), u_BuiltInToneMapping);
+    pbr = mix(pbr, pow(pbr, vec3(1.0 / 2.2)), u_BuiltInGammaCorrection);
 
     FRAGMENT_COLOR = vec4(pbr, albedo.a);
 #endif

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -121,7 +121,8 @@ public:
 		m_cameraMaterial.SetProperty("u_Albedo", FVector4{ 0.0f, 0.447f, 1.0f, 1.0f });
 		m_cameraMaterial.SetProperty("u_Metallic", 0.0f);
 		m_cameraMaterial.SetProperty("u_Roughness", 0.25f);
-		m_cameraMaterial.AddFeature("GAMMA_CORRECTION");
+		m_cameraMaterial.SetProperty("u_BuiltInGammaCorrection", true);
+		m_cameraMaterial.SetProperty("u_BuiltInToneMapping", true);
 	}
 
 protected:


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Reduced standard shader variant count from 256 to 32
* All functionalities have been kept, but some runtime branches got added (for clipping) where the cost is low enough
* Added built-in tonemapping to standard shader, so it can be used with gamma correction for UI and debug (no branch, low cost interpolation)
* Reduced standard shader compilation time by 10X

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes https://github.com/Overload-Technologies/Overload/issues/554

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.
