### PR TITLE
Fixed picking pass to only draw when the scene view is hovered

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Core/CameraController.h
@@ -84,6 +84,11 @@ namespace OvEditor::Core
 		bool IsRightMousePressed() const;
 
 		/**
+		* Returns true if the camera controller is currently operating
+		*/
+		bool IsOperating() const;
+
+		/**
 		* Lock the target actor to the given actor.
 		* @note Usefull to force orbital camera or camera focus to target a specific actor
 		* @param p_actor

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/CameraController.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/CameraController.cpp
@@ -258,6 +258,11 @@ bool OvEditor::Core::CameraController::IsRightMousePressed() const
 	return m_rightMousePressed;
 }
 
+bool OvEditor::Core::CameraController::IsOperating() const
+{
+	return m_rightMousePressed || m_middleMousePressed;
+}
+
 void OvEditor::Core::CameraController::LockTargetActor(OvCore::ECS::Actor& p_actor)
 {
 	m_lockedActor = p_actor;

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -156,6 +156,15 @@ OvCore::Rendering::SceneRenderer::SceneDescriptor OvEditor::Panels::SceneView::C
 
 void OvEditor::Panels::SceneView::DrawFrame()
 {
+	auto& pickingPass = m_renderer->GetPass<OvEditor::Rendering::PickingRenderPass>("Picking");
+
+	// Enable picking pass only when the scene view is hovered, not picking, and not operating the camera
+	pickingPass.SetEnabled(
+		IsHovered() &&
+		!m_gizmoOperations.IsPicking() &&
+		!m_cameraController.IsOperating()
+	);
+
 	OvEditor::Panels::AViewControllable::DrawFrame();
 	HandleActorPicking();
 }
@@ -183,7 +192,7 @@ void OvEditor::Panels::SceneView::HandleActorPicking()
 		m_gizmoOperations.StopPicking();
 	}
 
-	if (IsHovered() && !IsResizing())
+	if (!m_gizmoOperations.IsPicking() && IsHovered() && !IsResizing())
 	{
 		const auto pickingResult = GetPickingResult();
 
@@ -241,6 +250,7 @@ void OvEditor::Panels::SceneView::HandleActorPicking()
 
 		m_gizmoOperations.SetCurrentMouse({ static_cast<float>(mousePosition.first - m_position.x), static_cast<float>(mousePosition.second - m_position.y) });
 		m_gizmoOperations.ApplyOperation(m_camera.GetViewMatrix(), m_camera.GetProjectionMatrix(), m_camera.GetPosition(), { static_cast<float>(winWidth), static_cast<float>(winHeight) });
+		m_highlightedGizmoDirection = m_gizmoOperations.GetDirection();
 	}
 }
 

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -102,7 +102,6 @@ OvEditor::Rendering::PickingRenderPass::PickingResult OvEditor::Rendering::Picki
 
 void OvEditor::Rendering::PickingRenderPass::Draw(OvRendering::Data::PipelineState p_pso)
 {
-	// TODO: Make sure we only renderer when the view is hovered and not being resized
 	ZoneScoped;
 	TracyGpuZone("PickingRenderPass");
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
* Fixed picking pass to only draw when the scene view is hovered
* Also made gizmo arrows always higlighted during an operation

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #569

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/d798139f-fe51-4385-99e0-0bda2160e1b4


