### PR TITLE
Fixed assert when toggling picking render pass

### DIFF
--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/SceneView.cpp
@@ -115,6 +115,15 @@ void OvEditor::Panels::SceneView::InitFrame()
 		selectedActor,
 		m_highlightedGizmoDirection
 	});
+
+	auto& pickingPass = m_renderer->GetPass<OvEditor::Rendering::PickingRenderPass>("Picking");
+
+	// Enable picking pass only when the scene view is hovered, not picking, and not operating the camera
+	pickingPass.SetEnabled(
+		IsHovered() &&
+		!m_gizmoOperations.IsPicking() &&
+		!m_cameraController.IsOperating()
+	);
 }
 
 OvCore::SceneSystem::Scene* OvEditor::Panels::SceneView::GetScene()
@@ -156,15 +165,6 @@ OvCore::Rendering::SceneRenderer::SceneDescriptor OvEditor::Panels::SceneView::C
 
 void OvEditor::Panels::SceneView::DrawFrame()
 {
-	auto& pickingPass = m_renderer->GetPass<OvEditor::Rendering::PickingRenderPass>("Picking");
-
-	// Enable picking pass only when the scene view is hovered, not picking, and not operating the camera
-	pickingPass.SetEnabled(
-		IsHovered() &&
-		!m_gizmoOperations.IsPicking() &&
-		!m_cameraController.IsOperating()
-	);
-
 	OvEditor::Panels::AViewControllable::DrawFrame();
 	HandleActorPicking();
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
The picking render pass was being toggled in the middle of a frame, it's now done on frame init.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->
Write here.
