### PR TITLE
Added support for environment refraction

### DIFF
--- a/Resources/Engine/Shaders/Lighting/IBL.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/IBL.ovfxh
@@ -73,33 +73,51 @@ vec3 CalculateImageBasedLighting(
     float metallic,
     vec3 F0,
     float NdotV,
-    vec3 albedo
+    vec3 albedo,
+    float transmission,
+    float refractionIndex
 ) {
     // 0. Constants
     const int environmentMaxLOD = textureQueryLevels(environmentMap) - 1;
-    
+   
     // 1. Calculate reflection vector
     const vec3 R = ParallaxCorrect(reflect(-V, N), fragPos);
     
-    // 2. Diffuse irradiance (environment lighting)
-    const vec3 irradiance = textureLod(environmentMap, N, environmentMaxLOD).rgb; // High mip level for diffuse
+    // 2. Calculate refraction vector
+    const vec3 T = ParallaxCorrect(refract(-V, N, 1.0 / refractionIndex), fragPos);
+   
+    // 3. Diffuse irradiance (environment lighting)
+    const vec3 irradiance = textureLod(environmentMap, N, environmentMaxLOD).rgb;
+   
+    // 4. Specular reflection
+    const vec3 reflectedColor = textureLod(environmentMap, R, roughness * environmentMaxLOD).rgb;
     
-    // 3. Specular reflection
-    const vec3 prefilteredColor = textureLod(environmentMap, R, roughness * environmentMaxLOD).rgb;
+    // 5. Refracted environment sampling
+    const vec3 refractedColor = textureLod(environmentMap, T, roughness * environmentMaxLOD).rgb;
     
-    // 4. Apply BRDF
+    // 6. Apply BRDF
     const vec2 brdf = EnvBRDFApprox(NdotV, roughness);
-    
-    // 5. Calculate Fresnel for IBL
+   
+    // 7. Calculate Fresnel for IBL
     const vec3 F_IBL = FresnelSchlickRoughness(NdotV, F0, roughness);
     
-    // 6. Calculate specular and diffuse IBL components
+    // 8. Calculate transmission factor based on Fresnel
+    // Higher Fresnel = more reflection, less transmission
+    const float avgFresnel = (F_IBL.r + F_IBL.g + F_IBL.b) / 3.0;
+    const float transmissionFactor = transmission * (1.0 - avgFresnel);
+   
+    // 9. Calculate diffuse and reflection IBL components
     const vec3 kS_IBL = F_IBL;
     const vec3 kD_IBL = (1.0 - kS_IBL) * (1.0 - metallic);
-    
     const vec3 diffuseIBL = kD_IBL * irradiance * albedo;
-    const vec3 specularIBL = prefilteredColor * (F_IBL * brdf.x + brdf.y);
+    const vec3 reflectionIBL = reflectedColor * (F_IBL * brdf.x + brdf.y);
     
-    // 7. Return IBL contribution
+    // 10. Calculate refraction IBL component
+    const vec3 refractionIBL = refractedColor * albedo;
+
+    // 11. Mix reflection and refraction contributions based on transmission factor
+    const vec3 specularIBL = mix(reflectionIBL, refractionIBL, transmissionFactor);
+   
+    // 12. Return combined IBL contribution
     return (diffuseIBL + specularIBL) * ubo_ReflectionProbeData.brightness;
 }

--- a/Resources/Engine/Shaders/Lighting/PBR.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/PBR.ovfxh
@@ -72,7 +72,20 @@ vec3 CalculateBRDF(LightContribution lightContrib, vec3 V, vec3 N, vec3 albedo, 
     return (kD * albedo / PI + specular) * radiance * NdotL;
 }
 
-vec3 PBRLightingModel(vec3 albedo, float metallic, float roughness, float ao, vec3 normal, vec3 viewPos, vec3 fragPos, sampler2D shadowMap, mat4 lightSpaceMatrix, samplerCube environmentMap)
+vec3 PBRLightingModel(
+    vec3 albedo,
+    float metallic,
+    float roughness,
+    float ao,
+    vec3 normal,
+    vec3 viewPos,
+    vec3 fragPos,
+    sampler2D shadowMap,
+    mat4 lightSpaceMatrix,
+    samplerCube environmentMap,
+    float transmission,
+    float refractionIndex
+)
 {
     // Sanitize inputs
     metallic = clamp(metallic, 0.0, 1.0);
@@ -148,7 +161,9 @@ vec3 PBRLightingModel(vec3 albedo, float metallic, float roughness, float ao, ve
         metallic,
         F0,
         NdotV,
-        albedo
+        albedo,
+        transmission,
+        refractionIndex
     );
 #endif
 

--- a/Resources/Engine/Shaders/Standard.ovfx
+++ b/Resources/Engine/Shaders/Standard.ovfx
@@ -93,6 +93,9 @@ uniform sampler2D u_RoughnessMap;
 uniform float u_Roughness = 1.0;
 #endif
 
+uniform float u_RefractionIndex = 1.5; // 1.0 = air, 1.33 = water, 1.5 = glass, etc.
+uniform float u_Transmission = 0.0; // 0.0 = opaque, 1.0 = fully transmissive
+
 #if defined(NORMAL_MAPPING)
 uniform sampler2D u_NormalMap;
 #endif
@@ -200,7 +203,9 @@ void main()
         fs_in.FragPos,
         _ShadowMap,
         _LightSpaceMatrix,
-        _EnvironmentMap
+        _EnvironmentMap,
+        u_Transmission,
+        u_RefractionIndex
     );
 
     // Simple built-in tonemapping (Reinhard) and gamma correction for elements


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
The standard shader is now capable of showing environment refraction (using environment cubemaps generated by reflection probes).

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes https://github.com/Overload-Technologies/Overload/issues/570

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs

![image](https://github.com/user-attachments/assets/e5ae8e76-691c-458c-a041-ed9c3f269f73)


https://github.com/user-attachments/assets/29e57068-78b6-46f1-841e-f65374b5b262


