### PR TITLE
Added an editor setting to change reflection probe scale

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -90,6 +90,7 @@ namespace OvEditor::Settings
 		inline static Property<bool> EditorFrustumLightCulling = { true };
 		inline static Property<bool> DebugFrustumCulling = { false };
 		inline static Property<float> LightBillboardScale = { 0.5f };
+		inline static Property<float> ReflectionProbeScale = { 0.5f };
 		inline static Property<float> TranslationSnapUnit = { 1.0f };
 		inline static Property<float> RotationSnapUnit = { 15.0f };
 		inline static Property<float> ScalingSnapUnit = { 1.0f };

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -155,6 +155,9 @@ void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 	auto& lightBillboardScaleSlider = sceneViewBillboardScaleMenu.CreateWidget<Sliders::SliderInt>(0, 100, static_cast<int>(Settings::EditorSettings::LightBillboardScale * 100.0f), OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Lights");
 	lightBillboardScaleSlider.ValueChangedEvent += [this](int p_value) { Settings::EditorSettings::LightBillboardScale = p_value / 100.0f; };
 	lightBillboardScaleSlider.format = "%d %%";
+	auto& reflectionProbesScaleSlider = sceneViewBillboardScaleMenu.CreateWidget<Sliders::SliderInt>(0, 100, static_cast<int>(Settings::EditorSettings::ReflectionProbeScale * 100.0f), OvUI::Widgets::Sliders::ESliderOrientation::HORIZONTAL, "Reflection Probes");
+	reflectionProbesScaleSlider.ValueChangedEvent += [this](int p_value) { Settings::EditorSettings::ReflectionProbeScale = p_value / 100.0f; };
+	reflectionProbesScaleSlider.format = "%d %%";
 
 	auto& snappingMenu = m_settingsMenu->CreateWidget<MenuList>("Snapping");
 	snappingMenu.CreateWidget<Drags::DragFloat>(0.001f, 999999.0f, Settings::EditorSettings::TranslationSnapUnit, 0.05f, "Translation Unit").ValueChangedEvent += [this](float p_value) { Settings::EditorSettings::TranslationSnapUnit = p_value; };

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/DebugSceneRenderer.cpp
@@ -228,7 +228,7 @@ protected:
 							CalculateUnscaledModelMatrix(actor),
 							reflectionProbe->GetCapturePosition()
 						),
-						{ 0.5f, 0.5f, 0.5f }
+						OvMaths::FVector3::One * OvEditor::Settings::EditorSettings::ReflectionProbeScale
 					);
 
 				reflectionRenderFeature.PrepareProbe(*reflectionProbe);

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/OutlineRenderFeature.cpp
@@ -109,7 +109,9 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawActorToStencil(OvRendering::
 				reflectionProbeComponent->GetCapturePosition()
 			);
 			const auto rotation = OvMaths::FQuaternion::ToMatrix4(p_actor.transform.GetWorldRotation());
-			const auto scale = OvMaths::FMatrix4::Scaling({ 0.5f, 0.5f, 0.5f });
+			const auto scale = OvMaths::FMatrix4::Scaling(
+				OvMaths::FVector3::One * OvEditor::Settings::EditorSettings::ReflectionProbeScale
+			);
 			const auto model = translation * rotation * scale;
 			DrawModelToStencil(p_pso, model, *EDITOR_CONTEXT(editorResources)->GetModel("Sphere"));
 		}
@@ -158,7 +160,9 @@ void OvEditor::Rendering::OutlineRenderFeature::DrawActorOutline(
 				reflectionProbeComponent->GetCapturePosition()
 			);
 			const auto rotation = OvMaths::FQuaternion::ToMatrix4(p_actor.transform.GetWorldRotation());
-			const auto scale = OvMaths::FMatrix4::Scaling({ 0.5f, 0.5f, 0.5f });
+			const auto scale = OvMaths::FMatrix4::Scaling(
+				OvMaths::FVector3::One * OvEditor::Settings::EditorSettings::ReflectionProbeScale
+			);
 			const auto model = translation * rotation * scale;
 			DrawModelOutline(p_pso, model, *EDITOR_CONTEXT(editorResources)->GetModel("Sphere"), p_color);
 		}

--- a/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Rendering/PickingRenderPass.cpp
@@ -233,7 +233,9 @@ void OvEditor::Rendering::PickingRenderPass::DrawPickableReflectionProbes(OvRend
 				reflectionProbe->GetCapturePosition()
 			);
 			const auto rotation = OvMaths::FQuaternion::ToMatrix4(actor.transform.GetWorldRotation());
-			const auto scaling = OvMaths::FMatrix4::Scaling({ 0.5f, 0.5f, 0.5f });
+			const auto scaling = OvMaths::FMatrix4::Scaling(
+				OvMaths::FVector3::One * OvEditor::Settings::EditorSettings::ReflectionProbeScale
+			);
 			auto modelMatrix = translation * rotation * scaling;
 
 			m_renderer.GetFeature<DebugModelRenderFeature>()

--- a/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
@@ -39,6 +39,7 @@ void OvEditor::Settings::EditorSettings::Save()
 	iniFile.Add("editor_frustum_geometry_culling", EditorFrustumGeometryCulling.Get());
 	iniFile.Add("editor_frustum_light_culling", EditorFrustumLightCulling.Get());
 	iniFile.Add("light_billboard_scale", LightBillboardScale.Get());
+	iniFile.Add("reflection_probe_scale", ReflectionProbeScale.Get());
 	iniFile.Add("translation_snap_unit", TranslationSnapUnit.Get());
 	iniFile.Add("rotation_snap_unit", RotationSnapUnit.Get());
 	iniFile.Add("scaling_snap_unit", ScalingSnapUnit.Get());
@@ -56,6 +57,7 @@ void OvEditor::Settings::EditorSettings::Load()
 	LoadIniEntry<bool>(iniFile, "show_geometry_frustum_culling_in_scene_view", EditorFrustumGeometryCulling);
 	LoadIniEntry<bool>(iniFile, "show_light_frustum_culling_in_scene_view", EditorFrustumLightCulling);
 	LoadIniEntry<float>(iniFile, "light_billboard_scale", LightBillboardScale);
+	LoadIniEntry<float>(iniFile, "reflection_probe_scale", ReflectionProbeScale);
 	LoadIniEntry<float>(iniFile, "translation_snap_unit", TranslationSnapUnit);
 	LoadIniEntry<float>(iniFile, "rotation_snap_unit", RotationSnapUnit);
 	LoadIniEntry<float>(iniFile, "scaling_snap_unit", ScalingSnapUnit);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Reflection probe size can now be controlled using an editor setting exposed in the menu bar.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/40a1ce2a-c043-4965-97fc-c01d848a1163

