### PR TITLE
Added a setting to select font size in the editor

### DIFF
--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EFontSize.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EFontSize.h
@@ -1,0 +1,30 @@
+/**
+* @project: Overload
+* @author: Overload Tech.
+* @licence: MIT
+*/
+
+#pragma once
+
+namespace OvEditor::Settings
+{
+	enum class EFontSize
+	{
+		SMALL = 0,
+		MEDIUM = 1,
+		BIG = 2,
+		DEFAULT = MEDIUM
+	};
+
+	constexpr std::string_view GetFontID(EFontSize p_size)
+	{
+		switch (p_size)
+		{
+			case EFontSize::SMALL: return "Small";
+			case EFontSize::MEDIUM: return "Medium";
+			case EFontSize::BIG: return "Big";
+		}
+
+		return {};
+	}
+}

--- a/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
+++ b/Sources/Overload/OvEditor/include/OvEditor/Settings/EditorSettings.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <OvEditor/Settings/EFontSize.h>
 #include <OvTools/Eventing/Event.h>
 #include <OvUI/Styling/EStyle.h>
 
@@ -96,5 +97,6 @@ namespace OvEditor::Settings
 		inline static Property<float> ScalingSnapUnit = { 1.0f };
 		inline static Property<int> ColorTheme = { static_cast<int>(OvUI::Styling::EStyle::DEFAULT_DARK) };
 		inline static Property<int> ConsoleMaxLogs = { 500 };
+		inline static Property<int> FontSize = { static_cast<int>(EFontSize::DEFAULT) };
 	};
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/Context.cpp
@@ -126,10 +126,13 @@ OvEditor::Core::Context::Context(const std::filesystem::path& p_projectFolder) :
 		uiManager->ResetLayout(defaultLayoutPath.string());
 	}
 
-	uiManager->LoadFont("Ruda_Big", fontPath.string(), 16);
-	uiManager->LoadFont("Ruda_Small", fontPath.string(), 12);
-	uiManager->LoadFont("Ruda_Medium", fontPath.string(), 14);
-	uiManager->UseFont("Ruda_Medium");
+	uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::BIG) }, fontPath.string(), 18);
+	uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::MEDIUM) }, fontPath.string(), 15);
+	uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::SMALL) }, fontPath.string(), 12);
+	uiManager->UseFont(std::string{ Settings::GetFontID(
+		static_cast<Settings::EFontSize>(Settings::EditorSettings::FontSize.Get())
+	) });
+
 	uiManager->SetEditorLayoutSaveFilename(OvEditor::Utils::FileSystem::kLayoutFilePath.string());
 	uiManager->SetEditorLayoutAutosaveFrequency(60.0f);
 	uiManager->EnableEditorLayoutSave(true);

--- a/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Core/ProjectHub.cpp
@@ -288,8 +288,13 @@ void OvEditor::Core::ProjectHub::SetupContext()
 
 	const auto fontPath = std::filesystem::current_path() / "Data" / "Editor" / "Fonts" / "Ruda-Bold.ttf";
 
-	m_uiManager->LoadFont("Ruda", fontPath.string(), 18);
-	m_uiManager->UseFont("Ruda");
+	m_uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::BIG) }, fontPath.string(), 20);
+	m_uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::MEDIUM) }, fontPath.string(), 18);
+	m_uiManager->LoadFont(std::string{ Settings::GetFontID(Settings::EFontSize::SMALL) }, fontPath.string(), 16);
+	m_uiManager->UseFont(std::string{ Settings::GetFontID(
+		static_cast<Settings::EFontSize>(Settings::EditorSettings::FontSize.Get())
+	) });
+
 	m_uiManager->EnableEditorLayoutSave(false);
 	m_uiManager->EnableDocking(false);
 }

--- a/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Panels/MenuBar.cpp
@@ -90,6 +90,19 @@ void OvEditor::Panels::MenuBar::InitializeSettingsMenu()
 		EDITOR_CONTEXT(uiManager)->ApplyStyle(static_cast<OvUI::Styling::EStyle>(p_value));
 	};
 
+	auto& fontSizeMenu = m_settingsMenu->CreateWidget<MenuList>("Font Size");
+	auto& fontSizeSelector = fontSizeMenu.CreateWidget<Selection::ComboBox>(static_cast<int>(Settings::EditorSettings::FontSize.Get()));
+	fontSizeSelector.choices = {
+		{ static_cast<int>(Settings::EFontSize::SMALL), "Small"},
+		{ static_cast<int>(Settings::EFontSize::MEDIUM), "Medium"},
+		{ static_cast<int>(Settings::EFontSize::BIG), "Big"}
+	};
+	fontSizeSelector.ValueChangedEvent += [this](int p_value) {
+		Settings::EditorSettings::FontSize = p_value;
+		const auto fontID = std::string{ Settings::GetFontID(static_cast<Settings::EFontSize>(p_value)) };
+		EDITOR_CONTEXT(uiManager)->UseFont(fontID);
+	};
+
 	m_settingsMenu->CreateWidget<MenuItem>("Spawn actors at origin", "", true, true).ValueChangedEvent += EDITOR_BIND(SetActorSpawnAtOrigin, std::placeholders::_1);
 	m_settingsMenu->CreateWidget<MenuItem>("Vertical Synchronization", "", true, true).ValueChangedEvent += [this](bool p_value) { EDITOR_CONTEXT(device)->SetVsync(p_value); };
 	auto& cameraSpeedMenu = m_settingsMenu->CreateWidget<MenuList>("Camera Speed");

--- a/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
+++ b/Sources/Overload/OvEditor/src/OvEditor/Settings/EditorSettings.cpp
@@ -45,6 +45,7 @@ void OvEditor::Settings::EditorSettings::Save()
 	iniFile.Add("scaling_snap_unit", ScalingSnapUnit.Get());
 	iniFile.Add("color_theme", ColorTheme.Get());
 	iniFile.Add("console_max_logs", ConsoleMaxLogs.Get());
+	iniFile.Add("font_size", FontSize.Get());
 	iniFile.Rewrite();
 }
 
@@ -63,4 +64,5 @@ void OvEditor::Settings::EditorSettings::Load()
 	LoadIniEntry<float>(iniFile, "scaling_snap_unit", ScalingSnapUnit);
 	LoadIniEntry<int>(iniFile, "color_theme", ColorTheme);
 	LoadIniEntry<int>(iniFile, "console_max_logs", ConsoleMaxLogs);
+	LoadIniEntry<int>(iniFile, "font_size", FontSize);
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
On some monitors, Overload UI might appear small. This PR addresses that by adding a setting to select font size.

Some buttons might have overflowing text, which gets cutout, however this is still a necessary fix to make Overload usable with higher DPI monitors.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #406 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/fca636cb-e453-4489-9fcc-eb0133883a76


