### PR TITLE
Added support for tooltips to widgets

### DIFF
--- a/Sources/Overload/OvUI/include/OvUI/Widgets/AWidget.h
+++ b/Sources/Overload/OvUI/include/OvUI/Widgets/AWidget.h
@@ -71,6 +71,7 @@ namespace OvUI::Widgets
 		virtual void _Draw_Impl() = 0;
 
 	public:
+		std::string tooltip;
 		bool enabled = true;
 		bool disabled = false;
 		bool lineBreak = true;

--- a/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
+++ b/Sources/Overload/OvUI/src/OvUI/Widgets/AWidget.cpp
@@ -56,6 +56,14 @@ void OvUI::Widgets::AWidget::Draw()
 
 		_Draw_Impl();
 
+		if (!tooltip.empty())
+		{
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+			{
+				ImGui::SetTooltip(tooltip.c_str());
+			}
+		}
+
 		if (disabled)
 		{
 			ImGui::EndDisabled();


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Widgets can now show a tooltip! This allows for less verbose button labels, and more descriptive actions when hovered.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

![image](https://github.com/user-attachments/assets/adee8cf9-ad8b-4a13-9ee9-edf33ec3f856)

