### PR TITLE
Added a separator to the material renderer to separate visibility settings and materials

### DIFF
--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CMaterialRenderer.cpp
@@ -18,8 +18,10 @@
 #include <OvUI/Widgets/Buttons/ButtonSmall.h>
 #include <OvUI/Plugins/DDTarget.h>
 #include <OvUI/Widgets/InputFields/InputInt.h>
+#include <OvUI/Widgets/Layout/Dummy.h>
 #include <OvUI/Widgets/Layout/Group.h>
 #include <OvUI/Widgets/Texts/TextColored.h>
+#include <OvUI/Widgets/Visual/Separator.h>
 
 OvCore::ECS::Components::CMaterialRenderer::CMaterialRenderer(ECS::Actor & p_owner) : AComponent(p_owner)
 {
@@ -201,8 +203,13 @@ void OvCore::ECS::Components::CMaterialRenderer::OnInspector(OvUI::Internal::Wid
 	drawVisibilityToggle("Reflection", REFLECTION);
 	drawVisibilityToggle("Shadow", SHADOW);
 
+	p_root.CreateWidget<OvUI::Widgets::Visual::Separator>();
+	p_root.CreateWidget<OvUI::Widgets::Layout::Dummy>(); // Necessary to fill the "value" column
+
 	for (uint8_t i = 0; i < m_materials.size(); ++i)
+	{
 		m_materialFields[i] = CustomMaterialDrawer(p_root, "Material", m_materials[i]);
+	}
 
 	UpdateMaterialList();
 }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Since visibility settings got added to the material renderer component, visibility settings and material references were a bit hard to read. This PR adds a separator between the two sections.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
_N/A_

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

![image](https://github.com/user-attachments/assets/3144441c-a863-49c1-b914-e5cf7595f287)
