### PR TITLE
Added per-fragment reflection probe bound check

### DIFF
--- a/Resources/Engine/Shaders/Common/Buffers/ReflectionUBO.ovfxh
+++ b/Resources/Engine/Shaders/Common/Buffers/ReflectionUBO.ovfxh
@@ -6,4 +6,5 @@ layout (std140, binding = 1) uniform ReflectionUBO
     vec4 boxHalfExtents;
     float brightness;
     bool boxProjection;
+    bool local;
 } ubo_ReflectionProbeData;

--- a/Resources/Engine/Shaders/Lighting/IBL.ovfxh
+++ b/Resources/Engine/Shaders/Lighting/IBL.ovfxh
@@ -1,5 +1,14 @@
 #include ":Shaders/Common/Buffers/ReflectionUBO.ovfxh"
 
+bool IsPointInOBB(vec3 point, vec3 obbCenter, vec3 obbHalfExtents, mat3 obbOrientation)
+{
+    vec3 localPoint = obbOrientation * (point - obbCenter);
+    
+    return abs(localPoint.x) <= obbHalfExtents.x &&
+           abs(localPoint.y) <= obbHalfExtents.y &&
+           abs(localPoint.z) <= obbHalfExtents.z;
+}
+
 // https://seblagarde.wordpress.com/wp-content/uploads/2012/08/parallax_corrected_cubemap-siggraph2012.pdf
 vec3 BoxProjectionOBB(vec3 reflectionVector, vec3 worldPos, vec3 probePos, vec3 obbCenter, vec3 obbHalfExtents, mat3 obbOrientation)
 {
@@ -77,6 +86,17 @@ vec3 CalculateImageBasedLighting(
     float transmission,
     float refractionIndex
 ) {
+    // Early exit if the fragment is outside the reflection probe bounds
+    if (ubo_ReflectionProbeData.local && !IsPointInOBB(
+        fragPos,
+        ubo_ReflectionProbeData.boxCenter.xyz,
+        ubo_ReflectionProbeData.boxHalfExtents.xyz,
+        mat3(ubo_ReflectionProbeData.rotation))
+    )
+    {
+        return vec3(0.0); // No reflection/refraction.
+    }
+
     // 0. Constants
     const int environmentMaxLOD = textureQueryLevels(environmentMap) - 1;
    

--- a/Sources/Overload/OvCore/src/OvCore/ECS/Components/CReflectionProbe.cpp
+++ b/Sources/Overload/OvCore/src/OvCore/ECS/Components/CReflectionProbe.cpp
@@ -24,7 +24,8 @@ namespace
 		sizeof(OvMaths::FVector4) +	// Box Center (vec3)
 		sizeof(OvMaths::FVector4) +	// Box Extents (vec3)
 		sizeof(float) +				// Brightness (float)
-		sizeof(int);				// Box Projection (bool)
+		sizeof(int) +				// Box Projection (bool)
+		sizeof(int);				// Local (bool)
 
 	constexpr uint32_t kBackBufferIndex = 0; // Cubemap that is being rendered
 	constexpr uint32_t kCompleteBufferIndex = 1; // Cubemap that is used
@@ -432,7 +433,9 @@ void OvCore::ECS::Components::CReflectionProbe::_PrepareUBO()
 		OvMaths::FVector4 boxHalfExtents;
 		float brightness;
 		bool boxProjection;
-		std::byte padding[3];
+		std::byte padding1[3];
+		bool local;
+		std::byte padding2[3];
 	} uboDataPage{ 
 		.position = probePosition,
 		.rotation = probeRotationMatrix,
@@ -440,6 +443,7 @@ void OvCore::ECS::Components::CReflectionProbe::_PrepareUBO()
 		.boxHalfExtents = m_influenceSize,
 		.brightness = m_brightness,
 		.boxProjection = m_boxProjection && m_influencePolicy == EInfluencePolicy::LOCAL,
+		.local = m_influencePolicy == EInfluencePolicy::LOCAL,
 	};
 #pragma pack(pop)
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what this PR accomplishes -->
Added per-fragment reflection probe bound check.
It's now possible for a fragment to skip sampling the reflection probe (environment map) if the fragment is outside of the influence zone.

## Related Issue(s)
<!-- Link to the issue that this PR addresses (if applicable) -->
Fixes #595 

## Review Guidance
<!-- Provide any additional information that would help reviewing your work -->
Write here.

## Screenshots/GIFs
<!-- If applicable, add screenshots or GIFs demonstrating the changes -->

https://github.com/user-attachments/assets/1d7b60af-bc8b-4107-8198-a0bc8001d5b6


https://github.com/user-attachments/assets/ad2cc966-0bbd-4311-8990-8f5e2b933756



