### PR TITLE
Expose global bone transforms to Lua

### DIFF
--- a/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
+++ b/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
@@ -119,6 +119,21 @@ function SkinnedMeshRenderer:GetBoneLocalRotation(boneIndex) end
 ---@return Vector3|nil
 function SkinnedMeshRenderer:GetBoneLocalScale(boneIndex) end
 
+--- Returns the current bone global position in skeleton/model space, excluding the owning actor's world transform, or nil
+---@param boneIndex integer
+---@return Vector3|nil
+function SkinnedMeshRenderer:GetBoneGlobalPosition(boneIndex) end
+
+--- Returns the current bone global rotation in skeleton/model space, excluding the owning actor's world transform, or nil
+---@param boneIndex integer
+---@return Quaternion|nil
+function SkinnedMeshRenderer:GetBoneGlobalRotation(boneIndex) end
+
+--- Returns the current bone global scale in skeleton/model space, excluding the owning actor's world transform, or nil
+---@param boneIndex integer
+---@return Vector3|nil
+function SkinnedMeshRenderer:GetBoneGlobalScale(boneIndex) end
+
 --- Sets local bone position
 ---@param boneIndex integer
 ---@param position Vector3

--- a/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
@@ -205,6 +205,27 @@ namespace OvCore::ECS::Components
 		std::optional<OvMaths::FVector3> GetBoneLocalScale(uint32_t p_boneIndex) const;
 
 		/**
+		* Returns the current bone global position in skeleton/model space, excluding the owning actor's world transform
+		* @param p_boneIndex
+		* @return The bone global position, or std::nullopt if the bone index is invalid
+		*/
+		std::optional<OvMaths::FVector3> GetBoneGlobalPosition(uint32_t p_boneIndex) const;
+
+		/**
+		* Returns the current bone global rotation in skeleton/model space, excluding the owning actor's world transform
+		* @param p_boneIndex
+		* @return The bone global rotation, or std::nullopt if the bone index is invalid
+		*/
+		std::optional<OvMaths::FQuaternion> GetBoneGlobalRotation(uint32_t p_boneIndex) const;
+
+		/**
+		* Returns the current bone global scale in skeleton/model space, excluding the owning actor's world transform
+		* @param p_boneIndex
+		* @return The bone global scale, or std::nullopt if the bone index is invalid
+		*/
+		std::optional<OvMaths::FVector3> GetBoneGlobalScale(uint32_t p_boneIndex) const;
+
+		/**
 		* Sets the local bone position
 		* @param p_boneIndex
 		* @param p_position

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -103,7 +103,7 @@ namespace
 		return interpolate(prev, next, next.time - prev.time);
 	}
 
-	void DecomposeLocalTransform(
+	void DecomposeTransform(
 		const OvMaths::FMatrix4& p_matrix,
 		OvMaths::FVector3& p_position,
 		OvMaths::FQuaternion& p_rotation,
@@ -571,7 +571,7 @@ std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::
 	OvMaths::FVector3 position;
 	OvMaths::FQuaternion rotation;
 	OvMaths::FVector3 scale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	DecomposeTransform(m_localPose[*nodeIndex], position, rotation, scale);
 	return position;
 }
 
@@ -586,7 +586,7 @@ std::optional<OvMaths::FQuaternion> OvCore::ECS::Components::CSkinnedMeshRendere
 	OvMaths::FVector3 position;
 	OvMaths::FQuaternion rotation;
 	OvMaths::FVector3 scale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	DecomposeTransform(m_localPose[*nodeIndex], position, rotation, scale);
 	return rotation;
 }
 
@@ -601,7 +601,52 @@ std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::
 	OvMaths::FVector3 position;
 	OvMaths::FQuaternion rotation;
 	OvMaths::FVector3 scale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	DecomposeTransform(m_localPose[*nodeIndex], position, rotation, scale);
+	return scale;
+}
+
+std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneGlobalPosition(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value() || *nodeIndex >= m_globalPose.size())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeTransform(m_globalPose[*nodeIndex], position, rotation, scale);
+	return position;
+}
+
+std::optional<OvMaths::FQuaternion> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneGlobalRotation(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value() || *nodeIndex >= m_globalPose.size())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeTransform(m_globalPose[*nodeIndex], position, rotation, scale);
+	return rotation;
+}
+
+std::optional<OvMaths::FVector3> OvCore::ECS::Components::CSkinnedMeshRenderer::GetBoneGlobalScale(uint32_t p_boneIndex) const
+{
+	const auto nodeIndex = GetNodeIndexFromBoneIndex(p_boneIndex);
+	if (!nodeIndex.has_value() || *nodeIndex >= m_globalPose.size())
+	{
+		return std::nullopt;
+	}
+
+	OvMaths::FVector3 position;
+	OvMaths::FQuaternion rotation;
+	OvMaths::FVector3 scale;
+	DecomposeTransform(m_globalPose[*nodeIndex], position, rotation, scale);
 	return scale;
 }
 
@@ -616,7 +661,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalPosition(uint32_
 	OvMaths::FVector3 currentPosition;
 	OvMaths::FQuaternion currentRotation;
 	OvMaths::FVector3 currentScale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+	DecomposeTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
 
 	const OvMaths::FTransform transform(p_position, currentRotation, currentScale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
@@ -636,7 +681,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalRotation(uint32_
 	OvMaths::FVector3 currentPosition;
 	OvMaths::FQuaternion currentRotation;
 	OvMaths::FVector3 currentScale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+	DecomposeTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
 
 	const OvMaths::FTransform transform(currentPosition, p_rotation, currentScale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();
@@ -656,7 +701,7 @@ bool OvCore::ECS::Components::CSkinnedMeshRenderer::SetBoneLocalScale(uint32_t p
 	OvMaths::FVector3 currentPosition;
 	OvMaths::FQuaternion currentRotation;
 	OvMaths::FVector3 currentScale;
-	DecomposeLocalTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
+	DecomposeTransform(m_localPose[*nodeIndex], currentPosition, currentRotation, currentScale);
 
 	const OvMaths::FTransform transform(currentPosition, currentRotation, p_scale);
 	m_localPose[*nodeIndex] = transform.GetLocalMatrix();

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
@@ -122,6 +122,9 @@ void BindLuaComponents(sol::state& p_luaState)
 		"GetBoneLocalPosition", &CSkinnedMeshRenderer::GetBoneLocalPosition,
 		"GetBoneLocalRotation", &CSkinnedMeshRenderer::GetBoneLocalRotation,
 		"GetBoneLocalScale", &CSkinnedMeshRenderer::GetBoneLocalScale,
+		"GetBoneGlobalPosition", &CSkinnedMeshRenderer::GetBoneGlobalPosition,
+		"GetBoneGlobalRotation", &CSkinnedMeshRenderer::GetBoneGlobalRotation,
+		"GetBoneGlobalScale", &CSkinnedMeshRenderer::GetBoneGlobalScale,
 		"SetBoneLocalPosition", &CSkinnedMeshRenderer::SetBoneLocalPosition,
 		"SetBoneLocalRotation", &CSkinnedMeshRenderer::SetBoneLocalRotation,
 		"SetBoneLocalScale", &CSkinnedMeshRenderer::SetBoneLocalScale


### PR DESCRIPTION
## Description

Adds read-only access to the accumulated pose of a skinned mesh bone through `CSkinnedMeshRenderer` and Lua:

- `GetBoneGlobalPosition`
- `GetBoneGlobalRotation`
- `GetBoneGlobalScale`

The getters resolve a bone index to its skeleton node and decompose the matrix already computed in `m_globalPose`. Invalid indices return `std::nullopt` in C++ and `nil` in Lua, consistently with the existing local bone getters.

## Related Issue(s)

Fixes #831 

## Review Guidance

Please focus on:

- the distinction between local, skeleton-global/model-space, and world-space transforms;
- consistency with the existing `GetBoneLocalPosition`, `GetBoneLocalRotation`, and `GetBoneLocalScale` API;
- invalid bone-index handling in both C++ and Lua;
- the Lua API names and annotations.

The getters read `m_globalPose` before applying the bone offset matrix, which makes the returned transforms suitable for runtime bone attachments.

## Screenshots/GIFs


https://github.com/user-attachments/assets/5153229c-53ab-45b5-a918-daa4bf935277

<img width="1050" height="547" alt="image" src="https://github.com/user-attachments/assets/99109a24-565a-4003-9dea-ffca1c1004f6" />


## AI Usage Disclosure

N/A

## Checklist

- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
