### PR TITLE
Allow setting an animation source by asset path

### DIFF
--- a/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
+++ b/Resources/Engine/Lua/Components/SkinnedMeshRenderer.lua
@@ -55,9 +55,12 @@ function SkinnedMeshRenderer:SetTime(timeSeconds) end
 ---@return number
 function SkinnedMeshRenderer:GetTime() end
 
---- Sets an external model used as animation source, or nil to use the rendered model
----@param model Model|nil
-function SkinnedMeshRenderer:SetAnimationSourceModel(model) end
+--- Sets an external model used as animation source, either as a Model or as an asset path.
+--- A path is loaded on first use and cached by the model manager.
+--- Pass nil, or an empty path, to use the rendered model animations
+---@overload fun(self: SkinnedMeshRenderer, model: Model|nil)
+---@overload fun(self: SkinnedMeshRenderer, path: string)
+function SkinnedMeshRenderer:SetAnimationSourceModel(...) end
 
 --- Returns the external animation source model, or nil when the rendered model is used
 ---@return Model|nil

--- a/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
+++ b/Sources/OvCore/include/OvCore/ECS/Components/CSkinnedMeshRenderer.h
@@ -127,6 +127,14 @@ namespace OvCore::ECS::Components
 		void SetAnimationSourceModel(OvRendering::Resources::Model* p_model);
 
 		/**
+		* Sets the external model used as animation source, resolved from its asset path.
+		* The model is loaded on first use and kept by the model manager, so repeated calls with the
+		* same path are cheap. Pass an empty path to use the rendered model animations.
+		* @param p_path
+		*/
+		void SetAnimationSourceModel(const std::string& p_path);
+
+		/**
 		* Returns the external animation source model, or nullptr when the rendered model is used
 		*/
 		OvRendering::Resources::Model* GetAnimationSourceModel() const;

--- a/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
+++ b/Sources/OvCore/src/OvCore/ECS/Components/CSkinnedMeshRenderer.cpp
@@ -15,8 +15,10 @@
 #include <OvCore/ECS/Actor.h>
 #include <OvCore/ECS/Components/CModelRenderer.h>
 #include <OvCore/ECS/Components/CSkinnedMeshRenderer.h>
+#include <OvCore/Global/ServiceLocator.h>
 #include <OvCore/Helpers/GUIDrawer.h>
 #include <OvCore/Helpers/Serializer.h>
+#include <OvCore/ResourceManagement/ModelManager.h>
 #include <OvDebug/Logger.h>
 #include <OvMaths/FMatrix3.h>
 #include <OvMaths/FTransform.h>
@@ -435,6 +437,25 @@ void OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimationSourceModel(OvRe
 
 	m_animationSourceModel = p_model;
 	RebuildRuntimeData();
+}
+
+void OvCore::ECS::Components::CSkinnedMeshRenderer::SetAnimationSourceModel(const std::string& p_path)
+{
+	if (p_path.empty())
+	{
+		SetAnimationSourceModel(static_cast<OvRendering::Resources::Model*>(nullptr));
+		return;
+	}
+
+	auto* model = OvCore::Global::ServiceLocator::Get<OvCore::ResourceManagement::ModelManager>().GetResource(p_path);
+
+	if (!model)
+	{
+		OVLOG_WARNING("SkinnedMeshRenderer: Animation source model '" + p_path + "' could not be loaded.");
+		return;
+	}
+
+	SetAnimationSourceModel(model);
 }
 
 OvRendering::Resources::Model* OvCore::ECS::Components::CSkinnedMeshRenderer::GetAnimationSourceModel() const

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaComponentsBindings.cpp
@@ -105,7 +105,10 @@ void BindLuaComponents(sol::state& p_luaState)
 		"GetMeshBoundsScale", &CSkinnedMeshRenderer::GetMeshBoundsScale,
 		"SetTime", &CSkinnedMeshRenderer::SetTime,
 		"GetTime", &CSkinnedMeshRenderer::GetTime,
-		"SetAnimationSourceModel", &CSkinnedMeshRenderer::SetAnimationSourceModel,
+		"SetAnimationSourceModel", sol::overload(
+			sol::resolve<void(OvRendering::Resources::Model*)>(&CSkinnedMeshRenderer::SetAnimationSourceModel),
+			sol::resolve<void(const std::string&)>(&CSkinnedMeshRenderer::SetAnimationSourceModel)
+		),
 		"GetAnimationSourceModel", &CSkinnedMeshRenderer::GetAnimationSourceModel,
 		"IsAnimationSourceCompatible", &CSkinnedMeshRenderer::IsAnimationSourceCompatible,
 		"GetAnimationCount", &CSkinnedMeshRenderer::GetAnimationCount,


### PR DESCRIPTION
## Description
Adds a `const std::string&` overload of `CSkinnedMeshRenderer::SetAnimationSourceModel` that
resolves the path through `ModelManager`, and binds it alongside the existing `Model*` form.
Scripts can now assign an animation source, which was previously impossible: Lua has no way to
obtain a `Model*`.

Resolution lives in the component, next to the existing setter, so the binding stays a plain
`sol::overload` of two `sol::resolve` entries, the same shape already used for `SetAnimation`.
An empty path clears the source; an unresolvable one is logged and leaves the current source
untouched.

## Related Issue(s)
Fixes #835 

## Review Guidance
Behaviour of the existing `Model*` overload is unchanged; no current call site passes a literal
`nullptr`, so the added overload introduces no ambiguity. `CMaterialRenderer` already resolves its
assets through `ServiceLocator`, so the component-side dependency on `ModelManager` is not new.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)