### PR TITLE
Allow resizing of windows

### DIFF
--- a/Sources/OvEditor/src/OvEditor/Core/Context.cpp
+++ b/Sources/OvEditor/src/OvEditor/Core/Context.cpp
@@ -193,6 +193,7 @@ void OvEditor::Core::Context::ResetProjectSettings()
 	projectSettings.Add<int>("x_resolution", 1280);
 	projectSettings.Add<int>("y_resolution", 720);
 	projectSettings.Add<bool>("fullscreen", false);
+	projectSettings.Add<bool>("resizable", false);
 	projectSettings.Add<std::string>("executable_name", "Game");
 	projectSettings.Add<std::string>("start_scene", "");
 	projectSettings.Add<bool>("vsync", true);
@@ -209,6 +210,7 @@ bool OvEditor::Core::Context::IsProjectSettingsIntegrityVerified()
 		projectSettings.IsKeyExisting("x_resolution") &&
 		projectSettings.IsKeyExisting("y_resolution") &&
 		projectSettings.IsKeyExisting("fullscreen") &&
+		projectSettings.IsKeyExisting("resizable") &&
 		projectSettings.IsKeyExisting("executable_name") &&
 		projectSettings.IsKeyExisting("start_scene") &&
 		projectSettings.IsKeyExisting("vsync") &&

--- a/Sources/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/ProjectSettings.cpp
@@ -85,6 +85,7 @@ OvEditor::Panels::ProjectSettings::ProjectSettings(const std::string & p_title, 
 		GUIDrawer::DrawScalar<int>(columns, "Resolution X", GenerateGatherer<int>("x_resolution"), GenerateProvider<int>("x_resolution"), 1, 0, 10000);
 		GUIDrawer::DrawScalar<int>(columns, "Resolution Y", GenerateGatherer<int>("y_resolution"), GenerateProvider<int>("y_resolution"), 1, 0, 10000);
 		GUIDrawer::DrawBoolean(columns, "Fullscreen", GenerateGatherer<bool>("fullscreen"), GenerateProvider<bool>("fullscreen"));
+		GUIDrawer::DrawBoolean(columns, "Allow resizing", GenerateGatherer<bool>("resizable"), GenerateProvider<bool>("resizable"));
 		GUIDrawer::DrawString(columns, "Executable name", GenerateGatherer<std::string>("executable_name"), GenerateProvider<std::string>("executable_name"));
 		GUIDrawer::DrawAsset(columns, "Window Icon", GenerateGatherer<std::string>("window_icon"), GenerateProvider<std::string>("window_icon"), OvTools::Utils::PathParser::EFileType::TEXTURE);
 	}

--- a/Sources/OvGame/include/OvGame/Debug/DriverInfo.h
+++ b/Sources/OvGame/include/OvGame/Debug/DriverInfo.h
@@ -28,6 +28,15 @@ namespace OvGame::Debug
 		* @param p_window
 		*/
 		DriverInfo(OvRendering::Context::Driver& p_rdriver, OvWindowing::Window& p_window);
+
+
+        /**
+        * Update the data
+        */
+        void Update();
+
+    private:
+        OvWindowing::Window& m_window;
 	};
 }
 

--- a/Sources/OvGame/src/OvGame/Core/Context.cpp
+++ b/Sources/OvGame/src/OvGame/Core/Context.cpp
@@ -73,7 +73,7 @@ OvGame::Core::Context::Context() :
 	projectSettings.TryGet("x_resolution", targetWindowResolution[0]);
 	projectSettings.TryGet("y_resolution", targetWindowResolution[1]);
 	windowSettings.maximized = false;
-	windowSettings.resizable = false;
+	projectSettings.TryGet("resizable", windowSettings.resizable);
 	projectSettings.TryGet("fullscreen", windowSettings.fullscreen);
 	projectSettings.TryGet("samples", windowSettings.samples);
 
@@ -176,6 +176,10 @@ OvGame::Core::Context::Context() :
 		windowSettings.height,
 		true, false, false
 	);
+
+	window->FramebufferResizeEvent.AddListener([this](unsigned short width, unsigned short height) {
+		framebuffer->Resize(width, height);
+	});
 }
 
 OvGame::Core::Context::~Context()

--- a/Sources/OvGame/src/OvGame/Core/Game.cpp
+++ b/Sources/OvGame/src/OvGame/Core/Game.cpp
@@ -138,6 +138,7 @@ void OvGame::Core::Game::Update(float p_deltaTime)
 		auto& frameInfoRenderFeature = m_sceneRenderer.GetFeature<OvRendering::Features::FrameInfoRenderFeature>();
 		auto& frameInfo = frameInfoRenderFeature.GetFrameInfo();
 		m_frameInfo.Update(frameInfo);
+        m_driverInfo.Update();
 		#endif
 		m_context.uiManager->Render();
 	}

--- a/Sources/OvGame/src/OvGame/Debug/DriverInfo.cpp
+++ b/Sources/OvGame/src/OvGame/Debug/DriverInfo.cpp
@@ -8,7 +8,7 @@
 
 #include "OvGame/Debug/DriverInfo.h"
 
-OvGame::Debug::DriverInfo::DriverInfo(OvRendering::Context::Driver& p_driver, OvWindowing::Window& p_window)
+OvGame::Debug::DriverInfo::DriverInfo(OvRendering::Context::Driver& p_driver, OvWindowing::Window& p_window) : m_window(p_window)
 {
 	m_defaultHorizontalAlignment = OvUI::Settings::EHorizontalAlignment::RIGHT;
 	m_defaultVerticalAlignment = OvUI::Settings::EVerticalAlignment::BOTTOM;
@@ -24,6 +24,11 @@ OvGame::Debug::DriverInfo::DriverInfo(OvRendering::Context::Driver& p_driver, Ov
 	CreateWidget<OvUI::Widgets::Texts::TextColored>("Hardware: " + hardware, OvUI::Types::Color::Yellow);
 	CreateWidget<OvUI::Widgets::Texts::TextColored>("OpenGL Version: " + version, OvUI::Types::Color::Yellow);
 	CreateWidget<OvUI::Widgets::Texts::TextColored>("GLSL Version: " + shadingVersion, OvUI::Types::Color::Yellow);
+}
+
+void OvGame::Debug::DriverInfo::Update() {
+    SetPosition({ static_cast<float>(m_window.GetSize().first) - 10.f, static_cast<float>(m_window.GetSize().second) - 10.f });
+    SetAlignment(OvUI::Settings::EHorizontalAlignment::RIGHT, OvUI::Settings::EVerticalAlignment::BOTTOM);
 }
 
 #endif


### PR DESCRIPTION
## Description
This PR allows resizing of windows. Maybe we could also add a Lua-API to change window settings

## Review Guidance
- Framebuffer is resized
- ~~Widgets/Panels are currently not resized correctly~~

## Screenshots/GIFs
<img width="1280" height="720" alt="output" src="https://github.com/user-attachments/assets/405e5781-d13c-48a8-ae85-24c6ad1083de" />


## AI Usage Disclosure
None

## Checklist
- [x] My code follows the project's code style guidelines
- [ ] When applicable, I have commented my code, particularly in hard-to-understand areas
- [ ] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
- [x] ~~Currently, the debug driver info panel is not resized and moved properly~~

One thing: the project settings gets resetted every time we update them, I think we should change that in the future.