### PR TITLE
Preserve hierarchy actor order across scene reloads

### DIFF
--- a/Sources/OvCore/include/OvCore/SceneSystem/Scene.h
+++ b/Sources/OvCore/include/OvCore/SceneSystem/Scene.h
@@ -144,6 +144,13 @@ namespace OvCore::SceneSystem
 		bool DestroyActor(ECS::Actor& p_target);
 
 		/**
+		* Move the given actor at the end of the actor list, which defines the order in which
+		* actors are stored, updated and serialized
+		* @param p_actor
+		*/
+		void MoveActorToBack(ECS::Actor& p_actor);
+
+		/**
 		* Collect garbages by removing Destroyed-marked actors
 		*/
 		void CollectGarbages();

--- a/Sources/OvCore/src/OvCore/SceneSystem/Scene.cpp
+++ b/Sources/OvCore/src/OvCore/SceneSystem/Scene.cpp
@@ -324,6 +324,16 @@ bool OvCore::SceneSystem::Scene::DestroyActor(ECS::Actor& p_target)
 	}
 }
 
+void OvCore::SceneSystem::Scene::MoveActorToBack(ECS::Actor& p_actor)
+{
+	auto found = std::find(m_actors.begin(), m_actors.end(), &p_actor);
+
+	if (found != m_actors.end())
+	{
+		std::rotate(found, found + 1, m_actors.end());
+	}
+}
+
 void OvCore::SceneSystem::Scene::CollectGarbages()
 {
 	m_actors.erase(std::remove_if(m_actors.begin(), m_actors.end(), [this](ECS::Actor* element)

--- a/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
+++ b/Sources/OvEditor/src/OvEditor/Panels/Hierarchy.cpp
@@ -396,6 +396,8 @@ OvEditor::Panels::Hierarchy::Hierarchy
 		ConsiderWidget(*p_element.second);
 
 		p_element.first->DetachFromParent();
+
+		EDITOR_CONTEXT(sceneManager).GetCurrentScene()->MoveActorToBack(*p_element.first);
 	};
 
 	AddPlugin<ActorContextualMenu>(nullptr, nullptr);
@@ -540,6 +542,8 @@ void OvEditor::Panels::Hierarchy::AddActorByInstance(OvCore::ECS::Actor & p_acto
 		}
 
 		p_element.first->SetParent(p_actor);
+
+		EDITOR_CONTEXT(sceneManager).GetCurrentScene()->MoveActorToBack(*p_element.first);
 	};
 	auto& dispatcher = textSelectable.AddPlugin<OvUI::Plugins::DataDispatcher<std::string>>();
 


### PR DESCRIPTION
## Description
Reordering actors in the Hierarchy only moved their widgets. The scene actor list, which drives serialization and the hierarchy rebuild, was left untouched, so any reorder was lost on reload (Play/Stop, scene load).

`Scene::MoveActorToBack` moves an actor to the end of the actor list, and both Hierarchy drag & drop handlers call it after re-parenting. Sibling order in the actor list now matches the displayed order, and survives serialization.

## Related Issue(s)
Fixes #826

## Review Guidance
- The sync lives in the drag & drop handlers rather than in `Actor::AttachEvent`/`DettachEvent`: those also fire from `Actor::~Actor`, so reordering there would mutate `m_actors` during `CollectGarbages`/`DestroyActor`/`~Scene`.
- `OnDeserialize` re-attaches by ID, so a parent no longer preceding its children in the file is harmless.
- Also fixes the same divergence on attach: dropping B then A onto C displayed `C > [B, A]` but reloaded as `C > [A, B]`.
- Programmatic re-parenting (revert to prefab, Lua) still doesn't reorder the actor list — unchanged here.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)
