### PR TITLE
Expose script loading to the Lua API

### DIFF
--- a/Resources/Engine/Lua/Resources/Resources.lua
+++ b/Resources/Engine/Lua/Resources/Resources.lua
@@ -28,3 +28,9 @@ function Resources.GetMaterial(path) end
 ---@param path string
 ---@return Sound|nil
 function Resources.GetSound(path) end
+
+--- Loads (If not already loaded) and returns the value returned by the script identified by the given path. Returns nil on failure
+--- The returned value is shared by every script. It is discarded whenever the script engine reloads, which happens when entering play mode, when refreshing scripts, and when a Behaviour is removed
+---@param path string
+---@return any
+function Resources.GetScript(path) end

--- a/Sources/OvCore/include/OvCore/Scripting/Lua/LuaScriptEngine.h
+++ b/Sources/OvCore/include/OvCore/Scripting/Lua/LuaScriptEngine.h
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <OvCore/Scripting/Common/TScriptEngine.h>
@@ -19,6 +20,14 @@ namespace OvCore::ECS::Components
 
 namespace sol
 {
+	template <bool b>
+	class basic_reference;
+	using reference = basic_reference<false>;
+
+	template <typename base_type>
+	class basic_object;
+	using object = basic_object<reference>;
+
 	class state;
 }
 
@@ -68,5 +77,13 @@ namespace OvCore::Scripting
 		* Destroy the lua state
 		*/
 		void DestroyContext();
+
+		/**
+		* Loads (if not already loaded) and returns the value returned by the script identified
+		* by the given path. Returns nil on failure.
+		* The returned value is shared by every script, and is discarded along with the lua state.
+		* @param p_path
+		*/
+		sol::object GetScript(const std::string& p_path);
 	};
 }

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaGlobalBindings.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/Bindings/LuaGlobalBindings.cpp
@@ -23,6 +23,7 @@
 #include "OvCore/ResourceManagement/MaterialManager.h"
 #include "OvCore/ResourceManagement/SoundManager.h"
 #include "OvCore/Scripting/Common/ScriptPropertyValue.h"
+#include "OvCore/Scripting/ScriptEngine.h"
 
 #include <OvPhysics/Entities/PhysicalObject.h>
 
@@ -261,7 +262,8 @@ void BindLuaGlobal(sol::state& p_luaState)
 		"GetShader", [](const std::string& p_resPath) { return OVSERVICE(ShaderManager).GetResource(p_resPath); },
 		"GetTexture", [](const std::string& p_resPath) { return OVSERVICE(TextureManager).GetResource(p_resPath); },
 		"GetMaterial", [](const std::string& p_resPath) { return OVSERVICE(MaterialManager).GetResource(p_resPath); },
-		"GetSound", [](const std::string& p_resPath) { return OVSERVICE(SoundManager).GetResource(p_resPath); }
+		"GetSound", [](const std::string& p_resPath) { return OVSERVICE(SoundManager).GetResource(p_resPath); },
+		"GetScript", [](const std::string& p_resPath) { return OVSERVICE(ScriptEngine).GetScript(p_resPath); }
 	);
 
 	p_luaState.create_named_table("Math",

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
@@ -359,6 +359,10 @@ void OvCore::Scripting::LuaScriptEngine::CreateContext()
 	m_context.luaState = std::make_unique<sol::state>();
 	m_context.luaState->open_libraries(sol::lib::base, sol::lib::math);
 
+	(*m_context.luaState)["dofile"] = sol::nil;
+	(*m_context.luaState)["loadfile"] = sol::nil;
+	(*m_context.luaState)["load"] = sol::nil;
+
 	m_context.luaState->registry()[kLoadedScriptsKey] = m_context.luaState->create_table();
 	m_context.luaState->registry()[kLoadingScriptsKey] = m_context.luaState->create_table();
 

--- a/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
+++ b/Sources/OvCore/src/OvCore/Scripting/Lua/LuaScriptEngine.cpp
@@ -17,6 +17,7 @@
 #include <OvCore/Scripting/ScriptEngine.h>
 #include <OvCore/ECS/Components/Behaviour.h>
 #include <OvCore/ECS/Actor.h>
+#include <OvTools/Utils/PathParser.h>
 #include <OvTools/Utils/String.h>
 
 void BindLuaActor(sol::state& p_state);
@@ -27,6 +28,11 @@ void BindLuaProfiler(sol::state& p_state);
 
 namespace
 {
+	// Registry keys for the shared scripts. Living in the registry keeps them out of _G,
+	// and they die with the lua state, so Reload() invalidates them for free.
+	constexpr auto kLoadedScriptsKey = "__OverloadLoadedScripts";
+	constexpr auto kLoadingScriptsKey = "__OverloadLoadingScripts";
+
 	template<typename... Args>
 	void ExecuteLuaFunction(OvCore::ECS::Components::Behaviour& p_behaviour, const std::string& p_functionName, Args&& ...p_args)
 	{
@@ -80,6 +86,12 @@ namespace
 				return {};
 			}
 		}
+	}
+
+	bool IsWithinRoot(const std::filesystem::path& p_path, const std::filesystem::path& p_root)
+	{
+		const auto relativePath = p_path.lexically_relative(p_root);
+		return !relativePath.empty() && relativePath.begin()->string() != "..";
 	}
 
 	bool RegisterBehaviour(sol::state& p_luaState, OvCore::ECS::Components::Behaviour& p_behaviour, const std::string& p_scriptName)
@@ -347,6 +359,9 @@ void OvCore::Scripting::LuaScriptEngine::CreateContext()
 	m_context.luaState = std::make_unique<sol::state>();
 	m_context.luaState->open_libraries(sol::lib::base, sol::lib::math);
 
+	m_context.luaState->registry()[kLoadedScriptsKey] = m_context.luaState->create_table();
+	m_context.luaState->registry()[kLoadingScriptsKey] = m_context.luaState->create_table();
+
 	BindLuaActor(*m_context.luaState);
 	BindLuaComponents(*m_context.luaState);
 	BindLuaGlobal(*m_context.luaState);
@@ -384,4 +399,67 @@ void OvCore::Scripting::LuaScriptEngine::DestroyContext()
 	);
 
 	m_context.luaState.reset();
+}
+
+sol::object OvCore::Scripting::LuaScriptEngine::GetScript(const std::string& p_path)
+{
+	OVASSERT(m_context.luaState != nullptr, "No valid Lua context");
+
+	auto& luaState = *m_context.luaState;
+
+	const auto realPath = OvTools::Utils::PathParser::GetRealPath(
+		p_path,
+		m_context.engineAssetsPath,
+		m_context.projectAssetsPath
+	);
+
+	if (!IsWithinRoot(realPath, m_context.engineAssetsPath) && !IsWithinRoot(realPath, m_context.projectAssetsPath))
+	{
+		OVLOG_ERROR("'" + p_path + "' is outside of the assets folders");
+		return sol::make_object(luaState, sol::lua_nil);
+	}
+
+	if (!GetValidExtensions().contains(realPath.extension().string()))
+	{
+		OVLOG_ERROR("'" + p_path + "' isn't a script");
+		return sol::make_object(luaState, sol::lua_nil);
+	}
+
+	const auto key = realPath.generic_string();
+	sol::table loadedScripts = luaState.registry()[kLoadedScriptsKey];
+
+	if (const sol::object loaded = loadedScripts[key]; loaded.valid())
+	{
+		return loaded;
+	}
+
+	sol::table loadingScripts = luaState.registry()[kLoadingScriptsKey];
+
+	if (loadingScripts[key].valid())
+	{
+		OVLOG_ERROR("'" + p_path + "' is part of a circular script dependency");
+		return sol::make_object(luaState, sol::lua_nil);
+	}
+
+	loadingScripts[key] = true;
+	const auto result = luaState.safe_script_file(key, &sol::script_pass_on_error, sol::load_mode::text);
+	loadingScripts[key] = sol::lua_nil;
+
+	if (!result.valid())
+	{
+		sol::error err = result;
+		OVLOG_ERROR(err.what());
+		return sol::make_object(luaState, sol::lua_nil);
+	}
+
+	if (result.return_count() == 0)
+	{
+		OVLOG_ERROR("'" + p_path + "' missing return expression");
+		return sol::make_object(luaState, sol::lua_nil);
+	}
+
+	const sol::object script = result[0];
+	loadedScripts[key] = script;
+
+	return script;
 }


### PR DESCRIPTION
## Description
Adds `Resources.GetScript(path)`, which loads a `.lua` once and returns whatever the script returns, handing the same instance to every call site.

```lua
local VectorUtils = Resources.GetScript("Scripts/Utils/VectorUtils.lua")
```

- Paths go through `PathParser::GetRealPath`, so `:` resolves against engine assets.
- Rejects paths escaping both asset roots, and extensions outside `GetValidExtensions()`.
- Cycles are cut with an error instead of a stack overflow.
- The cache lives in the Lua registry: out of `_G`, and dropped when `Reload()` destroys the state.
- Behaviours are untouched, still re-executed per instance so each actor keeps its own table.

Uses `safe_script_file(..., script_pass_on_error, load_mode::text)` rather than sol2's `require_file`: Lua is built as C, so `SOL_PROPAGATE_EXCEPTIONS` is off and `require_file` fails through `lua_error` — a `longjmp` that cannot be caught and skips C++ destructors. Its cache is also only written after execution, so it cannot detect cycles.

The second commit removes `dofile`, `loadfile` and `load`, which resolved against the executable's working directory and accepted bytecode.

## Related Issue(s)
Fixes #838

## Review Guidance
- **Breaking.** `load` compiles strings, not files, so nothing here replaces it. The two commits are independent if you would rather take only the first.
- `.luarc.json` keeps `"basic": "enable"` since `print`, `pairs` and friends come from it. `runtime.builtin` is per-library, so the LSP still completes the three removed globals.
- Overlaps #751, which opens `sol::lib::package` on the same lines.
- A file used both as a Behaviour and through `GetScript` runs twice and yields two unrelated tables. Intended: Behaviours need per-actor state and their own injected `owner`.
- Shared state does not survive `RemoveBehaviour`, which reloads the whole state.
- The containment check is lexical, so a symlink inside the assets folder pointing outside would pass. `Scenes.Load` and the other `Resources.Get*` do not check containment at all today.

## Screenshots/GIFs
N/A

## AI Usage Disclosure
N/A

## Checklist
- [x] My code follows the project's code style guidelines
- [x] When applicable, I have commented my code, particularly in hard-to-understand areas
- [x] When applicable, I have updated the documentation accordingly
- [x] My changes don't generate new warnings or errors
- [x] I have reviewed and take responsibility for all code in this PR (including any AI-assisted contributions)